### PR TITLE
Add get-current-task and probe-read-kernel BPF helpers

### DIFF
--- a/src/compiler.lisp
+++ b/src/compiler.lisp
@@ -31,7 +31,9 @@
     ("PERF-EVENT-OUTPUT"    . 25)
     ("SKB-LOAD-BYTES"       . 26)
     ("PROBE-READ-STR"       . 45)
+    ("GET-CURRENT-TASK"     . 35)
     ("GET-CURRENT-CGROUP-ID" . 80)
+    ("PROBE-READ-KERNEL"    . 113)
     ("PROBE-READ-USER"      . 112)
     ("PROBE-READ-USER-STR"  . 114)
     ("RINGBUF-OUTPUT"       . 130)
@@ -42,9 +44,9 @@
    Single source of truth — referenced by the SSA pipeline via lower.lisp.")
 
 (defparameter *helper-arg-counts*
-  '(("PROBE-READ" . 3) ("PROBE-READ-USER" . 3)
+  '(("PROBE-READ" . 3) ("PROBE-READ-USER" . 3) ("PROBE-READ-KERNEL" . 3)
     ("PROBE-READ-STR" . 3) ("PROBE-READ-USER-STR" . 3)
-    ("KTIME-GET-NS" . 0) ("GET-PRANDOM-U32" . 0)
+    ("KTIME-GET-NS" . 0) ("GET-PRANDOM-U32" . 0) ("GET-CURRENT-TASK" . 0)
     ("GET-SMP-PROCESSOR-ID" . 0) ("GET-CURRENT-CGROUP-ID" . 0)
     ("GET-CURRENT-PID-TGID" . 0) ("GET-CURRENT-UID-GID" . 0)
     ("GET-CURRENT-COMM" . 2)


### PR DESCRIPTION
## Summary

These helpers are needed for eBPF programs that need to traverse kernel data structures (e.g., reading ppid from task_struct->real_parent->tgid).

- **get-current-task** (helper #35) returns a pointer to the current `task_struct`
- **probe-read-kernel** (helper #113) safely reads kernel memory, which is required because the BPF verifier rejects direct pointer dereference from get-current-task results

## Changes

- Added `GET-CURRENT-TASK` and `PROBE-READ-KERNEL` to `*builtin-helpers*`
- Added corresponding argument counts to `*helper-arg-counts*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)