### PR TITLE
Fix nil call-dst crash in hoist-loads-before-calls

### DIFF
--- a/src/ssa-opt.lisp
+++ b/src/ssa-opt.lisp
@@ -351,7 +351,8 @@
                                 (let ((ptr-vreg (first (ir-insn-args load-insn)))
                                       (call-dst (ir-insn-dst call-insn)))
                                   (when (and (integerp ptr-vreg)
-                                             (/= ptr-vreg call-dst))
+                                             (or (null call-dst)
+                                                 (/= ptr-vreg call-dst)))
                                     (setf new-insns (remove load-insn new-insns :count 1))
                                     (setf new-insns
                                           (append (subseq new-insns 0 i)


### PR DESCRIPTION
## Summary

When a BPF helper call has no destination register (e.g., an unused `ktime-get-ns` result), `ir-insn-dst` returns NIL. The `hoist-loads-before-calls` optimization pass then crashes with "The value NIL is not of type NUMBER" when comparing `(/= ptr-vreg call-dst)`.

This adds a nil guard so void helper calls are handled correctly.

## Changes

- Added `(or (null call-dst) ...)` guard around the `/=` comparison in `hoist-loads-before-calls`

🤖 Generated with [Claude Code](https://claude.com/claude-code)