### PR TITLE
Add :value-type to defmap for explicit struct-valued maps

### DIFF
--- a/src/protocols.lisp
+++ b/src/protocols.lisp
@@ -223,6 +223,13 @@
   (let ((spec (map-spec-for map-name)))
     (if spec (getf (rest spec) :value-size) 8)))
 
+(defun struct-value-map-p (map-name)
+  "Check if MAP-NAME was declared with :value-type (a struct).
+   When true, getmap returns the map_value pointer directly instead of
+   dereferencing it as a scalar."
+  (let ((spec (map-spec-for map-name)))
+    (and spec (getf (rest spec) :value-type))))
+
 (defmacro incf-map (map key-form &optional (delta 1))
   "Atomically increment a map value. For array maps where the key always exists,
    this is just a lookup + atomic-add. For hash maps, initializes to DELTA if
@@ -258,25 +265,41 @@
                        (map-update ,map ,k ,init 0)))))))))
 
 (defmacro getmap (map key-form)
-  "Look up a map value and dereference the pointer. Returns the value
-   using the map's value-size type, or 0 if the key is not found.
+  "Look up a map value. For scalar values (≤8 bytes), dereferences the
+   pointer and returns the value. For struct values (>8 bytes), returns
+   the map_value pointer directly so fields can be accessed with struct
+   accessors. Returns 0/nil if the key is not found.
    Automatically uses -ptr operations for struct key maps."
   (let ((p (gensym "P"))
         (vtype (map-value-type map))
         (lookup (if (struct-key-map-p map) 'map-lookup-ptr 'map-lookup)))
-    `(let ((,p u64 (,lookup ,map ,key-form)))
-       (if ,p (load ,vtype ,p 0) 0))))
+    (if (struct-value-map-p map)
+        ;; Struct value: return the pointer directly
+        `(,lookup ,map ,key-form)
+        ;; Scalar value: dereference
+        `(let ((,p u64 (,lookup ,map ,key-form)))
+           (if ,p (load ,vtype ,p 0) 0)))))
 
 (defmacro set-getmap! (map key-form val-form)
-  "Writer macro for (setf (getmap map key) val)."
+  "Writer macro for (setf (getmap map key) val).
+   For struct-valued maps, val-form should be a pointer to a stack-allocated
+   struct (e.g., from make-<struct>). For scalar maps, val-form is a value."
   (let ((v (gensym "V"))
         (vtype (map-value-type map)))
-    (if (struct-key-map-p map)
-        `(let ((,v (struct-alloc ,(map-value-size-bytes map))))
-           (store ,vtype ,v 0 ,val-form)
-           (map-update-ptr ,map ,key-form ,v 0))
-        `(let ((,v ,vtype ,val-form))
-           (map-update ,map ,key-form ,v 0)))))
+    (cond
+      ((struct-value-map-p map)
+       ;; Struct value: val-form is a pointer, use map-update-ptr or map-update
+       ;; with the struct pointer directly
+       (if (struct-key-map-p map)
+           `(map-update-ptr ,map ,key-form ,val-form 0)
+           `(map-update ,map ,key-form ,val-form 0)))
+      ((struct-key-map-p map)
+       `(let ((,v (struct-alloc ,(map-value-size-bytes map))))
+          (store ,vtype ,v 0 ,val-form)
+          (map-update-ptr ,map ,key-form ,v 0)))
+      (t
+       `(let ((,v ,vtype ,val-form))
+          (map-update ,map ,key-form ,v 0))))))
 
 (cl:defsetf getmap set-getmap!)
 

--- a/src/whistler.lisp
+++ b/src/whistler.lisp
@@ -402,13 +402,26 @@
 
 ;;; User-facing macros for defining maps and programs
 
-(defmacro defmap (name &key type (key-size 0) (value-size 0) max-entries (map-flags 0))
+(defmacro defmap (name &key type (key-size 0) (value-size 0) value-type
+                           max-entries (map-flags 0))
   "Define a BPF map. KEY-SIZE and VALUE-SIZE default to 0 (appropriate for
-   ringbuf maps which don't use traditional key/value pairs)."
-  `(push (list ',name :type ,type :key-size ,key-size
-                      :value-size ,value-size :max-entries ,max-entries
-                      :map-flags ,map-flags)
-         *maps*))
+   ringbuf maps which don't use traditional key/value pairs).
+   VALUE-TYPE optionally names a struct defined with defstruct.  When provided,
+   VALUE-SIZE is derived automatically from the struct definition, and getmap
+   returns a map_value pointer instead of a dereferenced scalar."
+  (let ((vs (if value-type
+                (let ((def (gethash (string value-type) *struct-defs*)))
+                  (unless def
+                    (error "defmap ~a: :value-type ~a is not a known struct. ~
+                            Define it with defstruct before defmap." name value-type))
+                  (car def))
+                value-size)))
+    `(push (list ',name :type ,type :key-size ,key-size
+                        :value-size ,vs
+                        ,@(when value-type `(:value-type ',value-type))
+                        :max-entries ,max-entries
+                        :map-flags ,map-flags)
+           *maps*)))
 
 (defmacro defprog (name (&key (type :xdp) (section nil) (license "GPL"))
                    &body body)
@@ -539,9 +552,10 @@
   (let ((map-structs
          (loop for map-spec in maps
                for idx from 0
-               collect (destructuring-bind (name &key type key-size value-size max-entries
-                                                 (map-flags 0))
+               collect (destructuring-bind (name &key type key-size value-size value-type
+                                                 max-entries (map-flags 0))
                            map-spec
+                         (declare (ignore value-type))
                          (make-bpf-map
                           :name name
                           :type (whistler/compiler:resolve-map-type type)


### PR DESCRIPTION
## Summary

- `defmap` now accepts `:value-type`, naming a `defstruct` type
- When set, `:value-size` is derived automatically from the struct definition
- `getmap` returns the `map_value` pointer directly (for struct field access) instead of dereferencing it as a scalar
- `(setf (getmap ...))` passes the struct pointer to `map-update` directly
- When `:value-type` is not set, behavior is unchanged

## Motivation

Previously, `getmap` on a struct-valued map (e.g., `value-size 40`) would expand to `(load u64 ptr 0)` — returning the first 8 bytes as a scalar. This made struct field accessors like `(my-struct-field val)` silently wrong (they'd try to dereference a scalar), and the BPF verifier would reject the program with "invalid mem access 'scalar'".

Users had to know to use `map-lookup` instead of `getmap` for struct maps, which was undocumented and surprising.

## Example

```lisp
(defstruct my-stats
  (count u64)
  (total u64))

;; Before: had to use value-size and remember to use map-lookup, not getmap
(defmap stats :type :hash :key-size 4 :value-size 16 :max-entries 1024)

;; After: value-size derived, getmap returns pointer
(defmap stats :type :hash :key-size 4 :value-type my-stats :max-entries 1024)

;; getmap now works naturally with struct accessors
(when-let ((s (getmap stats pid)))
  (setf (my-stats-count s) (+ (my-stats-count s) 1)))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)