### PR TITLE
Add kernel-load surface form for safe kernel memory access

### DIFF
--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -152,4 +152,6 @@
            ;; pt_regs access (x86-64)
            #:pt-regs-parm1 #:pt-regs-parm2 #:pt-regs-parm3
            #:pt-regs-parm4 #:pt-regs-parm5 #:pt-regs-parm6
-           #:pt-regs-ret))
+           #:pt-regs-ret
+           ;; Safe kernel memory access
+           #:kernel-load))

--- a/src/protocols.lisp
+++ b/src/protocols.lisp
@@ -170,6 +170,29 @@
       (push `(get-current-comm (,comm-field ,event) ,(or comm-size 16)) forms))
     `(progn ,@(nreverse forms))))
 
+;;; ---- kernel-load ----
+
+(defmacro kernel-load (type ptr offset)
+  "Safely read a value of TYPE at byte OFFSET from a kernel pointer PTR.
+   Compiles to probe-read-kernel into a stack buffer followed by a load.
+   Use this instead of (load TYPE PTR OFFSET) when PTR is a kernel address
+   (e.g., from get-current-task) that the BPF verifier does not trust for
+   direct memory access.
+
+   Example:
+     ;; Read task_struct->tgid (u32 at offset 2772) safely
+     (kernel-load u32 task 2772)
+
+     ;; Equivalent to the manual pattern:
+     (let ((buf (struct-alloc 4)))
+       (probe-read-kernel buf 4 (+ task 2772))
+       (load u32 buf 0))"
+  (let ((buf (gensym "KBUF"))
+        (byte-size (cl:case type (u8 1) (u16 2) (u32 4) (u64 8) (t 8))))
+    `(let ((,buf (struct-alloc ,byte-size)))
+       (probe-read-kernel ,buf ,byte-size (+ ,ptr ,offset))
+       (load ,type ,buf 0))))
+
 ;;; ---- incf / decf ----
 
 (defmacro incf (place &optional (delta 1))


### PR DESCRIPTION
Addresses #16.

## Summary

- Adds `kernel-load` macro: `(kernel-load type ptr offset)` → safe kernel memory read
- Compiles to `struct-alloc` + `probe-read-kernel` + `load` (no new IR ops)
- Exported from the `whistler` package

## Motivation

`get-current-task` returns a BPF scalar, not a verifier-trusted pointer. Direct `(load ...)` on the result is rejected by the verifier. Users currently need a 5-line boilerplate pattern for each field read. `kernel-load` reduces this to a single form.

## Example

```lisp
;; Read task_struct->real_parent->tgid
(let* ((task       (get-current-task))
       (parent-ptr (kernel-load u64 task 2784))   ; real_parent
       (ppid       (kernel-load u32 parent-ptr 2772)))  ; tgid
  ...)
```

This is the recommended way to access kernel struct fields from kprobe/tracepoint programs. The `import-kernel-struct` accessors use direct `load` which only works with verifier-trusted pointers (map values, ctx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)