### PR TITLE
Add sk_lookup program support: compile, load, and attach

### DIFF
--- a/examples/sk-lookup-catchall.lisp
+++ b/examples/sk-lookup-catchall.lisp
@@ -1,0 +1,33 @@
+;;; sk-lookup-catchall.lisp — Catch-all sk_lookup that pins every
+;;; incoming TCP/UDP connection to a single pre-stashed socket.
+;;;
+;;; SPDX-License-Identifier: MIT
+;;;
+;;; A userspace process opens a listener, pins its fd into REDIR-SOCKMAP
+;;; at index 0, then loads + attaches this program to a netns. The
+;;; kernel calls into us during the listener-lookup path for every
+;;; inbound TCP SYN / UDP packet; we look up index 0 and assign the
+;;; connection to that socket, regardless of the destination port. This
+;;; is the building block for protocol-aware service routing on top of
+;;; a single bound port.
+
+(in-package #:whistler)
+
+;; SOCKMAP holds a single struct sock * pointer keyed by u32. A lookup in
+;; sk_lookup context returns a *reference-counted* socket (the verifier
+;; tags it with a ref_obj_id), so the reference must be released with
+;; sk-release before the program exits — bpf_sk_assign borrows the socket
+;; but does not consume the reference. Skipping the release is a verifier
+;; error ("unreleased reference ... reference leak").
+(defmap redir-sockmap :type :sockmap
+  :key-size 4 :value-size 8 :max-entries 1)
+
+(defprog catch-all (:type :sk-lookup :section "sk_lookup" :license "GPL")
+  ;; Single-socket redirect: look up slot 0 in the sockmap and, if
+  ;; populated, pin this connection to it, then release the socket
+  ;; reference. SK_PASS in any case so the kernel proceeds with its normal
+  ;; listener resolution when the sockmap is empty (e.g. during setup).
+  (when-let ((sk (map-lookup redir-sockmap 0)))
+    (sk-assign (ctx-ptr) sk 0)
+    (sk-release sk))
+  SK_PASS)

--- a/src/bpf.lisp
+++ b/src/bpf.lisp
@@ -97,6 +97,11 @@
 (defconstant +bpf-map-type-lpm-trie+      11)
 (defconstant +bpf-map-type-stack-trace+   7)
 (defconstant +bpf-map-type-ringbuf+       27)
+;; sockmap/sockhash hold struct sock * values keyed by an integer
+;; (sockmap) or arbitrary bytes (sockhash). Used by sk_lookup /
+;; sk_skb / sockops to redirect to a stashed socket.
+(defconstant +bpf-map-type-sockmap+       15)
+(defconstant +bpf-map-type-sockhash+      18)
 
 ;; Map flags
 (defconstant +bpf-f-no-prealloc+ 1)

--- a/src/compiler.lisp
+++ b/src/compiler.lisp
@@ -56,7 +56,13 @@
     ("SEND-SIGNAL"          . 109)
     ("OVERRIDE-RETURN"      . 58)
     ("JIFFIES64"            . 118)
-    ("PER-CPU-PTR"          . 153))
+    ("PER-CPU-PTR"          . 153)
+    ;; sk_lookup helpers — used by BPF_PROG_TYPE_SK_LOOKUP programs to
+    ;; redirect connection establishment to a chosen socket.
+    ("SK-LOOKUP-TCP"        . 84)
+    ("SK-LOOKUP-UDP"        . 85)
+    ("SK-RELEASE"           . 86)
+    ("SK-ASSIGN"            . 124))
   "BPF helper functions: string name → helper ID.
    Single source of truth — referenced by the SSA pipeline via lower.lisp.")
 
@@ -78,7 +84,10 @@
     ("RINGBUF-OUTPUT" . 4)
     ("GET-SOCKET-COOKIE" . 1) ("GET-CURRENT-TASK-BTF" . 0)
     ("KTIME-GET-COARSE-NS" . 0) ("KTIME-GET-BOOT-NS" . 0) ("KTIME-GET-TAI-NS" . 0)
-    ("GET-STACKID" . 3))
+    ("GET-STACKID" . 3)
+    ;; sk_lookup helpers
+    ("SK-LOOKUP-TCP" . 5) ("SK-LOOKUP-UDP" . 5)
+    ("SK-RELEASE" . 1) ("SK-ASSIGN" . 3))
   "Expected argument counts for BPF helpers that users call directly.
    BPF allows max 5 args (R1-R5). Helpers not listed here are not checked.")
 
@@ -98,7 +107,10 @@
     ("TC_ACT_OK"       . 0)
     ("TC_ACT_SHOT"     . 2)
     ("TC_ACT_STOLEN"   . 4)
-    ("TC_ACT_REDIRECT" . 7))
+    ("TC_ACT_REDIRECT" . 7)
+    ;; sk_lookup return codes
+    ("SK_DROP" . 0)
+    ("SK_PASS" . 1))
   "BPF constants: string name → integer value.")
 
 ;;; Map type name resolution
@@ -113,7 +125,9 @@
     (:lpm-trie      +bpf-map-type-lpm-trie+)
     (:percpu-array  +bpf-map-type-percpu-array+)
     (:stack-trace   +bpf-map-type-stack-trace+)
-    (:ringbuf       +bpf-map-type-ringbuf+)))
+    (:ringbuf       +bpf-map-type-ringbuf+)
+    (:sockmap       +bpf-map-type-sockmap+)
+    (:sockhash      +bpf-map-type-sockhash+)))
 
 ;;; Data structures
 
@@ -170,7 +184,8 @@
     (:cgroup-skb        . "__sk_buff")
     (:cgroup-sock-addr  . "bpf_sock_addr")
     (:cgroup-sock       . "bpf_sock_ops")
-    (:tc                . "__sk_buff")))
+    (:tc                . "__sk_buff")
+    (:sk-lookup         . "bpf_sk_lookup")))
 
 (defparameter *ctx-struct-fields*
   '(("xdp_md" .
@@ -230,7 +245,22 @@
       (local-ip6     (:array u32 4) 116)
       (remote-port   u32 132)
       (local-port    u32 136)
-      (data-meta     u32 140)))))
+      (data-meta     u32 140)))
+    ;; sk_lookup context — fields verified against this kernel's BTF
+    ;; (struct bpf_sk_lookup, size 72). remote-port is __be16 but the
+    ;; surrounding 4-byte slot is what the verifier permits the program
+    ;; to load; we expose it as u16 for the in-network-byte-order value.
+    ("bpf_sk_lookup" .
+     ((sk             :ptr 0)
+      (family         u32  8)
+      (protocol       u32  12)
+      (remote-ip4     u32  16)
+      (remote-ip6     (:array u32 4) 20)
+      (remote-port    u16  36)
+      (local-ip4      u32  40)
+      (local-ip6      (:array u32 4) 44)
+      (local-port     u32  60)
+      (ingress-ifindex u32 64)))))
 
 (defun ctx-resolve-field (prog-type field-name &optional index)
   "Resolve a context field name to (values type offset struct-name c-field-name)

--- a/src/loader/attach.lisp
+++ b/src/loader/attach.lisp
@@ -498,6 +498,36 @@
                                   (handler-case (sb-posix:close link-fd)
                                     (error () nil)))))))
 
+;;; ========== sk_lookup attachment ==========
+
+(defun attach-sk-lookup (prog-fd &key (netns-path "/proc/self/ns/net"))
+  "Attach an SK_LOOKUP program to a network namespace via BPF_LINK_CREATE.
+
+   NETNS-PATH names the netns whose listener-lookup path the program
+   intercepts; defaults to the caller's current namespace. The program
+   must have been loaded with expected_attach_type=BPF_SK_LOOKUP — the
+   loader does this automatically when the ELF section is sk_lookup or
+   sk_lookup/<name>.
+
+   Returns an attachment whose detach closes the link and netns fds."
+  (let ((netns-fd (sb-posix:open netns-path sb-posix:o-rdonly 0)))
+    (when (< netns-fd 0)
+      (error 'bpf-error :context (format nil "open netns ~a" netns-path)
+                         :errno (sb-alien:get-errno)))
+    (handler-bind ((error (lambda (c)
+                            (declare (ignore c))
+                            (sb-posix:close netns-fd))))
+      (let ((buf (make-attr-buf 168)))
+        (put-u32 buf 0 prog-fd)
+        (put-u32 buf 4 netns-fd)
+        (put-u32 buf 8 +bpf-sk-lookup+)
+        (let ((link-fd (%bpf +bpf-link-create+ buf 168 "sk-lookup-link-create")))
+          (make-attachment
+           :type :sk-lookup :perf-fds nil :prog-fd prog-fd
+           :cleanup (lambda ()
+                      (handler-case (sb-posix:close link-fd) (error () nil))
+                      (handler-case (sb-posix:close netns-fd) (error () nil)))))))))
+
 ;;; ========== XDP attachment ==========
 
 (defun attach-xdp (prog-fd interface-name &key (mode "xdp"))

--- a/src/loader/packages.lisp
+++ b/src/loader/packages.lisp
@@ -24,7 +24,8 @@
    #:map-info-fd #:map-info-name
    ;; Attachment
    #:attach-kprobe #:attach-uprobe #:attach-tracepoint #:attach-xdp #:attach-tc
-   #:attach-cgroup #:attach-lsm #:attach-fentry #:attach-kprobe-multi #:detach
+   #:attach-cgroup #:attach-lsm #:attach-fentry #:attach-kprobe-multi
+   #:attach-sk-lookup #:detach
    #:attach-obj-kprobe #:attach-obj-uprobe #:attach-obj-cgroup
    #:attach-obj-xdp #:attach-obj-tc
    ;; Cgroup constants

--- a/src/loader/program.lisp
+++ b/src/loader/program.lisp
@@ -119,6 +119,12 @@
                 (string= rest "bind4")
                 (string= rest "bind6"))))
      +bpf-prog-type-cgroup-sock-addr+)
+    ;; sk_lookup — listener-lookup hook, prog type 30. Must be loaded
+    ;; with expected_attach_type=BPF_SK_LOOKUP and attached to a netns.
+    ((or (string= section-name "sk_lookup")
+         (and (>= (length section-name) 10)
+              (string= (subseq section-name 0 10) "sk_lookup/")))
+     +bpf-prog-type-sk-lookup+)
     (t +bpf-prog-type-socket-filter+)))
 
 (defun section-to-expected-attach-type (section-name)
@@ -151,6 +157,12 @@
          (and (>= (length section-name) 16)
               (string= (subseq section-name 0 16) "kretprobe.multi/")))
      +bpf-trace-kprobe-multi+)
+    ;; sk_lookup load REJECTS without expected_attach_type=BPF_SK_LOOKUP —
+    ;; the kernel verifies prog_type + EAT pair before reading the program.
+    ((or (string= section-name "sk_lookup")
+         (and (>= (length section-name) 10)
+              (string= (subseq section-name 0 10) "sk_lookup/")))
+     +bpf-sk-lookup+)
     (t nil)))
 
 ;;; ========== Program loading ==========

--- a/src/loader/syscall.lisp
+++ b/src/loader/syscall.lisp
@@ -51,6 +51,8 @@
 (defconstant +bpf-map-type-lru-hash+ 9)
 (defconstant +bpf-map-type-stack-trace+ 7)
 (defconstant +bpf-map-type-ringbuf+ 27)
+(defconstant +bpf-map-type-sockmap+ 15)
+(defconstant +bpf-map-type-sockhash+ 18)
 
 ;;; ========== BPF program types ==========
 
@@ -75,6 +77,11 @@
 (defconstant +bpf-prog-type-lsm+ 29)
 (defconstant +bpf-prog-type-syscall+ 31)
 (defconstant +bpf-prog-type-raw-tracepoint+ 17)
+;; sk_lookup: program runs in TCP/UDP listener lookup path. Must be
+;; loaded with expected_attach_type = +bpf-sk-lookup+ (36) and attached
+;; via BPF_LINK_CREATE against a network-namespace fd.
+(defconstant +bpf-prog-type-sk-lookup+ 30)
+(defconstant +bpf-sk-lookup+ 36)
 (defconstant +bpf-f-sleepable+ #x10)
 
 ;;; ========== BPF commands (attach/detach) ==========

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -50,6 +50,7 @@
    #:+bpf-map-type-lpm-trie+
    #:+bpf-map-type-percpu-hash+ #:+bpf-map-type-percpu-array+
    #:+bpf-map-type-ringbuf+ #:+bpf-map-type-stack-trace+
+   #:+bpf-map-type-sockmap+ #:+bpf-map-type-sockhash+
    ;; Map flags
    #:+bpf-f-no-prealloc+
    ;; Helper function IDs


### PR DESCRIPTION
## What

End-to-end support for `BPF_PROG_TYPE_SK_LOOKUP` — the programmable
listener-lookup hook (Linux 5.9+) that lets a single socket answer for any
port within a network namespace.

**Compiler**
- `sk_lookup` program type + its `bpf_sk_lookup` context struct (static field
  table, with the usual BTF resolution)
- helpers: `bpf_sk_assign` (124), `bpf_sk_lookup_tcp` (84),
  `bpf_sk_lookup_udp` (85), `bpf_sk_release` (86)
- `:sockmap` / `:sockhash` map types

**Loader**
- section-name → `BPF_PROG_TYPE_SK_LOOKUP` and the required
  `expected_attach_type = BPF_SK_LOOKUP`
- `attach-sk-lookup`: creates a BPF link against a netns fd — the loader's
  first netns-targeted `BPF_LINK_CREATE`

**Example**
- `examples/sk-lookup-catchall.lisp`: look a socket up in a sockmap, assign
  the connection to it, release the socket reference, `SK_PASS`.

## Why

sk_lookup is the kernel primitive for "one socket serves every port" — L4
proxies, catch-all listeners, and protocol-multiplexing front ends. It was the
major socket-steering program type Whistler couldn't yet express.

## Verification

Verified on Linux 7.0 (kernel verifier + attach) driving the pure-CL loader,
no libbpf or bpftool:

- trivial `SK_PASS`: loads (`prog-type=30`, `expected_attach_type=36`),
  verifier-accepted, attaches to a netns, detaches.
- catch-all (sockmap + `sk_assign` + `sk_release`, 17 insns): map created,
  verifier-accepted, attaches, detaches.

A reference-counting detail worth a reviewer's eye: a sockmap lookup in
sk_lookup context returns a **reference-counted** socket (`ref_obj_id`), so the
program must `bpf_sk_release` it before exit even though `bpf_sk_assign` only
borrows it. The example reflects this; without the release the verifier rejects
with *"unreleased reference … reference leak"*.

## Notes for reviewers
- Constants pinned against the UAPI headers: prog-type `SK_LOOKUP` = 30,
  attach-type `BPF_SK_LOOKUP` = 36 (easy to conflate).
- No new external dependencies.

© Brian O'Reilly <fade@deepsky.com>, 2026
