### PR TITLE
kfunc support: call BPF kfuncs with acquire/release + ret-null checks (#44)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
             name=$(basename "$f" .lisp)
             # Skip examples that drive the loader / need kernel access
             case "$name" in
-              ffi-call-tracker|fork-tracker|cgroup-skb-count|cgroup-skb-session) continue ;;
+              ffi-call-tracker|fork-tracker|cgroup-skb-count|cgroup-skb-session|kfunc-task) continue ;;
             esac
             sbcl --noinform --non-interactive \
               --eval '(require :asdf)' \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable user-facing changes per release. Newest first.
 
+## Unreleased
+
+### New Features
+
+#### kfunc support — calling BPF kernel functions (issue #44)
+
+BPF programs can now call kfuncs — the extensible kernel functions that
+have replaced the frozen helper set. Resolution is by BTF at load time,
+on Whistler's pure-CL toolchain (no libbpf): a call compiles to a
+`BPF_PSEUDO_KFUNC_CALL`, the ELF carries an `R_BPF_64_32` relocation
+against an extern BTF `FUNC`, and the loader patches in the kfunc's
+vmlinux BTF id. Both load paths handle it — the `.bpf.o` loader and the
+in-memory session/bpftrace-runtime path.
+
+Call a kfunc by name like a helper; six ship predeclared
+(`bpf-rcu-read-lock`/`unlock`, `bpf-task-from-pid`/`bpf-task-release`,
+`bpf-cgroup-from-id`/`bpf-cgroup-release`). Declare your own with
+`defkfunc`. Acquire/release and maybe-null pointers are modeled and
+checked at compile time (a leaked acquired reference or an unguarded
+`:ret-null` result is a compile error); the verifier remains
+authoritative for per-path completeness and the per-program-type kfunc
+allowlist. Available from both the Whistler surface language and the
+bpftrace frontend (call by kernel symbol name). See
+`examples/kfunc-task.lisp` and `examples/bpftrace/kfunc-rcu.bt`.
+
 ## 1.10.0 — 2026-05-28
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Programs are defined with `defprog`, maps with `defmap`, structs with `defstruct
 
 Use `(declare (type ...))` for narrowing when inference can't determine the type (integer literals, arithmetic results).
 
-Key forms: `let` (parallel bindings, standard CL), `let*` (sequential bindings), `if`, `when`, `unless`, `when-let`, `if-let`, `return`, `load`, `store`, `logand`, `logxor`, `>>`, `ash`, `cast`, `ctx`, `map-lookup`, `map-update`, `map-delete`, `map-lookup-ptr`, `struct-alloc`, `stack-addr`, `tail-call`, `get-prandom-u32`, `sizeof`, `memset`, `memcpy`, `do-user-ptrs`, `do-user-array`, `with-ringbuf`, `fill-process-info`, `pt-regs-parm1`..`parm6`, `pt-regs-ret`, protocol accessors.
+Key forms: `let` (parallel bindings, standard CL), `let*` (sequential bindings), `if`, `when`, `unless`, `when-let`, `if-let`, `return`, `load`, `store`, `logand`, `logxor`, `>>`, `ash`, `cast`, `ctx`, `map-lookup`, `map-update`, `map-delete`, `map-lookup-ptr`, `struct-alloc`, `stack-addr`, `tail-call`, `get-prandom-u32`, `sizeof`, `memset`, `memcpy`, `do-user-ptrs`, `do-user-array`, `with-ringbuf`, `fill-process-info`, `pt-regs-parm1`..`parm6`, `pt-regs-ret`, `defkfunc` (declare a kfunc) and kfunc calls by name, protocol accessors.
 
 `setf` supports CL-style multi-pair: `(setf place1 val1 place2 val2 ...)`. `defmap` defaults `:key-size` and `:value-size` to 0 (omit for ringbuf maps).
 
@@ -75,6 +75,21 @@ Key forms: `let` (parallel bindings, standard CL), `let*` (sequential bindings),
 Context access: `(ctx field-name)` reads a field from the program's context struct, resolved by program type (e.g., `:xdp` uses `xdp_md`, `:cgroup-sock-addr` uses `bpf_sock_addr`). `(setf (ctx field-name) val)` writes. Array fields: `(ctx user-ip6 0)`. Legacy `(ctx u32 4)` with explicit type+offset still works. Field-name access emits CO-RE relocations for compile-once portability; offsets are resolved from BTF at compile time when `/sys/kernel/btf/vmlinux` is available, falling back to a static table.
 
 Memory ops: `(memset ptr off val n)` with widened stores, `(memcpy dst doff src soff n)` with wide load/store pairs. `(pt-regs-parm1)` through `(pt-regs-parm6)` and `(pt-regs-ret)` for uprobe/kprobe context access (x86-64 and aarch64; compile-time error on unsupported architectures).
+
+### kfuncs
+
+kfuncs are kernel functions a BPF program *calls* — the extensible replacement for the frozen helper set. Whistler resolves them by BTF at load time (no libbpf): a kfunc call compiles to a `BPF_PSEUDO_KFUNC_CALL`, the ELF carries an `R_BPF_64_32` relocation against an extern BTF `FUNC`, and the loader patches in the kfunc's vmlinux BTF id. Both load paths patch kfunc relocs — the ELF loader (`patch-kfunc-relocations` in `loader.lisp`) and the session/bpftrace-runtime path (`session-load-progs` in `session.lisp`).
+
+Call a kfunc by name like a helper: `(bpf-task-from-pid pid)`. Six kfuncs ship predeclared (`bpf-rcu-read-lock`/`unlock`, `bpf-task-from-pid`/`bpf-task-release`, `bpf-cgroup-from-id`/`bpf-cgroup-release`). Declare your own with `defkfunc`:
+
+```lisp
+(defkfunc bpf-task-from-pid ((pid s32)) (ptr task_struct) :acquire :ret-null)
+(defkfunc bpf-task-release  ((task (ptr task_struct))) void :release)
+```
+
+The Lisp name maps to the kernel symbol by turning hyphens into underscores. Types are `u8`..`u64`, `s32`/`s64`, `void`, or `(ptr STRUCT)`. Flags drive compile-time checks: `:acquire` (result is a refcounted pointer that must be released — leaking it is a compile error), `:release` (consumes an acquired reference), `:ret-null` (result may be NULL and must be null-checked; passing a bare maybe-null result to another kfunc is a compile error); `:trusted`/`:sleepable` are recorded but verifier-enforced. The BPF verifier remains authoritative for per-path completeness and for the per-program-type kfunc allowlist (e.g. `bpf_task_from_pid` is TRACING/syscall-only, not kprobe/xdp). The shared registry `*builtin-kfuncs*` in `compiler.lisp` is the single source of truth for both frontends and the loader. See `examples/kfunc-task.lisp` (Whistler) and `examples/bpftrace/kfunc-rcu.bt` (bpftrace).
+
+The registry (`*builtin-kfuncs*`), lowering (`lower-kfunc-call` + acquire/release leak check in `lower.lisp`), BTF extern FUNC emission (`btf-add-kfunc` in `btf.lisp`), and ELF relocs (`elf.lisp`) are shared; the bpftrace frontend recognizes a kfunc by its kernel name in `lower-call` (`codegen.lisp`) and emits the same Whistler kfunc call.
 
 ## Userspace Loader (whistler/loader)
 

--- a/README.md
+++ b/README.md
@@ -376,6 +376,42 @@ int synflood(struct xdp_md *ctx) {
 </td></tr>
 </table>
 
+### Calling kfuncs
+
+kfuncs are kernel functions a BPF program *calls* — the extensible
+replacement for the frozen helper set (`bpf_task_from_pid`,
+`bpf_rcu_read_lock`, `bpf_cgroup_from_id`, …). Whistler resolves them by
+BTF at load time, with no libbpf: a call compiles to a
+`BPF_PSEUDO_KFUNC_CALL`, the object carries an `R_BPF_64_32` relocation
+against an extern BTF `FUNC`, and the loader patches in the kfunc's
+vmlinux BTF id.
+
+Call a kfunc by name like a helper. Whistler models the two obligations
+kfunc pointers carry and enforces them at compile time:
+
+```lisp
+;; bpf_task_from_pid ACQUIRES a refcounted task* that may be NULL.
+(defprog task-demo (:type :kprobe :section "test_run/task_demo")
+  (let ((task (bpf-task-from-pid 1)))   ; :ret-null → must null-check
+    (when task                          ; guard the maybe-null pointer
+      (bpf-task-release task)))         ; :acquire → must release, or
+  0)                                    ;   "acquired reference is never
+                                        ;    released" at compile time
+```
+
+Six kfuncs ship predeclared; declare your own with `defkfunc`:
+
+```lisp
+(defkfunc bpf-task-from-pid ((pid s32)) (ptr task_struct) :acquire :ret-null)
+(defkfunc bpf-task-release  ((task (ptr task_struct))) void :release)
+```
+
+The same kfuncs are callable from the bpftrace frontend by their kernel
+symbol name. The kernel gates each kfunc to specific program types (e.g.
+`bpf_task_from_pid` is tracing/syscall-only), which the verifier enforces.
+See [`examples/kfunc-task.lisp`](examples/kfunc-task.lisp) and
+[`examples/bpftrace/kfunc-rcu.bt`](examples/bpftrace/kfunc-rcu.bt).
+
 ## Userspace loader
 
 `whistler/loader` is a pure Common Lisp BPF loader — no libbpf, no CFFI.
@@ -471,6 +507,10 @@ Almost everything you'd write in a typical bpftrace script:
   (compile-time stat), `signal(N)` (send to current task),
   `override(retval)` (kprobe error injection), `jiffies()`, `is_err(p)`,
   `kptr(p)` / `uptr(p)` (identity), `cpid()` / `has_cpid()` (from `-c`).
+- **kfunc calls**: call a BPF kfunc by its kernel symbol name, e.g.
+  `bpf_rcu_read_lock()` / `bpf_rcu_read_unlock()`, `bpf_task_from_pid(pid)`
+  / `bpf_task_release($t)` — resolved by BTF at load time, with the same
+  acquire/release + null-check checks as the Whistler frontend.
 - **Compile-time type predicates**: `is_str`, `is_ptr`, `is_array`,
   `is_integer`, `is_unsigned_integer`, `is_literal` — fold to 0/1 for
   `if comptime (is_str($x)) { … }` macro dispatch.

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -22,6 +22,7 @@
   - [Map Operations](./language/maps.md)
   - [Ring Buffers](./language/ringbuf.md)
   - [BPF Helpers](./language/helpers.md)
+  - [kfuncs](./language/kfuncs.md)
   - [Loops](./language/loops.md)
   - [Tail Calls](./language/tail-calls.md)
   - [Inline Assembly](./language/asm.md)

--- a/book/src/bpftrace/surface.md
+++ b/book/src/bpftrace/surface.md
@@ -151,6 +151,36 @@ equivalent. Currently honored:
 [Maps and aggregations](#maps-and-aggregations) table above. All of
 these must appear on the right-hand side of `@m = …`.
 
+### kfunc calls
+
+Call a BPF kfunc by its kernel symbol name, like any function:
+
+```
+kprobe:vfs_read {
+  bpf_rcu_read_lock();
+  @reads = count();
+  bpf_rcu_read_unlock();
+}
+
+fentry:vfs_read {
+  $t = bpf_task_from_pid(pid);   // acquires a refcounted task*
+  if ($t) {                      // must null-check (may be NULL)
+    @calls = count();
+    bpf_task_release($t);        // must release before returning
+  }
+}
+```
+
+kfuncs are resolved by BTF at load time, with the same acquire/release
+and null-check guarantees as the Whistler frontend — the bpftrace
+compiler lowers a kfunc call into a Whistler kfunc call. The kernel gates
+each kfunc to specific program types: `bpf_rcu_read_lock` /
+`bpf_rcu_read_unlock` work under `kprobe`; acquire/release kfuncs such as
+`bpf_task_from_pid` / `bpf_task_release` are tracing-only, so call them
+from `fentry:` / `kfunc:` probes. See the
+[kfuncs chapter](../language/kfuncs.md) for the full model and
+`defkfunc` for declaring additional kfuncs.
+
 ## Operators
 
 C-style: `+ - * / % == != < > <= >= && || ! & | ^ << >> ~`. Compound

--- a/book/src/language/kfuncs.md
+++ b/book/src/language/kfuncs.md
@@ -1,0 +1,101 @@
+# kfuncs
+
+kfuncs (BPF kernel functions) are the modern, extensible way the kernel
+exposes capabilities to BPF programs — the replacement for the frozen
+[helper](./helpers.md) set. Unlike helpers, kfuncs have no stable integer
+IDs; they are resolved by BTF at load time. Whistler does this on its own
+pure-CL toolchain, with no libbpf:
+
+- a kfunc call compiles to a `BPF_PSEUDO_KFUNC_CALL` instruction,
+- the ELF object carries an `R_BPF_64_32` relocation against an extern
+  BTF `FUNC` symbol,
+- the loader resolves the kfunc's type id in `/sys/kernel/btf/vmlinux`
+  and patches it into the call's immediate.
+
+Call a kfunc by name in function position, exactly like a helper:
+
+```lisp
+(bpf-rcu-read-lock)
+(let ((task (bpf-task-from-pid pid)))
+  ...)
+```
+
+The Lisp name maps to the kernel symbol by turning hyphens into
+underscores: `bpf-task-from-pid` → `bpf_task_from_pid`.
+
+## Predeclared kfuncs
+
+Six kfuncs ship ready to call:
+
+| Whistler name | Signature | Flags |
+|---------------|-----------|-------|
+| `bpf-rcu-read-lock` | `() → void` | |
+| `bpf-rcu-read-unlock` | `() → void` | |
+| `bpf-task-from-pid` | `(s32) → task_struct*` | `:acquire :ret-null` |
+| `bpf-task-release` | `(task_struct*) → void` | `:release` |
+| `bpf-cgroup-from-id` | `(u64) → cgroup*` | `:acquire :ret-null` |
+| `bpf-cgroup-release` | `(cgroup*) → void` | `:release` |
+
+## Acquire / release and maybe-null pointers
+
+Many useful kfuncs hand back a *refcounted* pointer that may be NULL.
+Whistler models both obligations and checks them at compile time so you
+get a clear error instead of a raw verifier log:
+
+- **`:ret-null`** — the result may be NULL and must be null-checked
+  before use. Passing a bare maybe-null result straight into another
+  kfunc is a compile error; bind it and guard it with `when`/`if`.
+- **`:acquire`** — the returned reference must be released on the way out
+  via its paired `:release` kfunc. Leaking it is a compile error:
+  *"acquired reference from BPF-TASK-FROM-PID is never released."*
+
+```lisp
+(defprog task-demo (:type :kprobe :section "test_run/task_demo")
+  (let ((task (bpf-task-from-pid 1)))   ; :ret-null → must null-check
+    (when task                          ; guard the maybe-null pointer
+      (bpf-task-release task)))         ; :acquire → must release
+  0)
+```
+
+The compile-time checks are a fast, friendly first line of defense. The
+BPF verifier remains authoritative: it enforces per-path release
+completeness (released on one branch but not another) and the
+per-program-type kfunc allowlist.
+
+## Program-type gating
+
+The kernel registers each kfunc for specific program types. For example
+`bpf_task_from_pid` is allowed for tracing / syscall / raw_tracepoint
+programs but **not** plain kprobe or XDP — loading it there fails the
+verifier with *"calling kernel function ... is not allowed."* This is
+kernel policy, not a Whistler limitation. `bpf_rcu_read_lock` /
+`bpf_rcu_read_unlock` are allowed under most types, including kprobe.
+
+## Declaring your own kfunc
+
+Use `defkfunc` to declare any kfunc the running kernel exports:
+
+```lisp
+(defkfunc bpf-task-from-pid ((pid s32)) (ptr task_struct) :acquire :ret-null)
+(defkfunc bpf-task-release  ((task (ptr task_struct))) void :release)
+```
+
+- **Parameters** are `(var type)` pairs; the variable names are for
+  readability only.
+- **Types** are `u8`..`u64`, `s32`/`s64`, `void`, or `(ptr STRUCT)` for a
+  pointer to a kernel struct.
+- **Flags** are `:acquire`, `:release`, `:ret-null` (drive the compile-time
+  checks above), plus `:trusted` and `:sleepable` (recorded, but enforced
+  by the verifier).
+
+`defkfunc` extends the shared registry that both the Whistler and
+bpftrace frontends and the loader consume, so a declared kfunc is
+immediately callable from either language.
+
+## Example
+
+See [`examples/kfunc-task.lisp`](https://github.com/atgreen/whistler/blob/main/examples/kfunc-task.lisp)
+for a complete program that acquires a task, releases it, and runs in the
+kernel via `BPF_PROG_TEST_RUN`. The same kfuncs are callable from the
+[bpftrace frontend](../bpftrace/surface.md) by their kernel symbol name —
+see [`examples/bpftrace/kfunc-rcu.bt`](https://github.com/atgreen/whistler/blob/main/examples/bpftrace/kfunc-rcu.bt).

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -570,6 +570,50 @@ Arguments are loaded into R1–R5 (max 5). The return value is in R0.
 | `get-current-task-btf` | 159 | Current task_struct (BTF pointer) |
 | `ktime-get-coarse-ns` | 161 | Coarse monotonic clock (faster, less precise) |
 
+### kfunc calls
+
+```lisp
+(bpf-rcu-read-lock)
+(let ((task (bpf-task-from-pid pid)))
+  (when task
+    (bpf-task-release task)))
+```
+
+kfuncs are kernel functions the program *calls* — the extensible
+replacement for the frozen helper set. Unlike helpers they have no stable
+IDs; they are resolved by BTF at load time (no libbpf). A kfunc call
+compiles to a `BPF_PSEUDO_KFUNC_CALL`, the ELF carries an `R_BPF_64_32`
+relocation against an extern BTF `FUNC`, and the loader patches in the
+kfunc's vmlinux BTF id. Call one by name in function position; the Lisp
+name maps to the kernel symbol by turning hyphens into underscores
+(`bpf-task-from-pid` → `bpf_task_from_pid`).
+
+Six kfuncs ship predeclared: `bpf-rcu-read-lock`, `bpf-rcu-read-unlock`,
+`bpf-task-from-pid`, `bpf-task-release`, `bpf-cgroup-from-id`,
+`bpf-cgroup-release`. Declare others with `defkfunc`:
+
+```lisp
+(defkfunc bpf-task-from-pid ((pid s32)) (ptr task_struct) :acquire :ret-null)
+(defkfunc bpf-task-release  ((task (ptr task_struct))) void :release)
+```
+
+Parameters are `(var type)` pairs; types are `u8`..`u64`, `s32`/`s64`,
+`void`, or `(ptr STRUCT)`. Flags drive compile-time checks:
+
+- `:acquire` — the result is a refcounted pointer that must be released
+  via its paired `:release` kfunc; leaking it is a compile error.
+- `:release` — consumes an acquired reference.
+- `:ret-null` — the result may be NULL and must be null-checked before
+  use; passing a bare maybe-null result to another kfunc is a compile
+  error.
+- `:trusted`, `:sleepable` — recorded, but enforced by the verifier.
+
+The verifier is authoritative for per-path release completeness and for
+the per-program-type kfunc allowlist (e.g. `bpf_task_from_pid` is
+tracing/syscall-only, not kprobe/xdp; `bpf_rcu_read_lock`/`unlock` work
+under most types). The same kfuncs are callable from the bpftrace
+frontend by their kernel symbol name.
+
 ### Bounded loops
 
 ```lisp

--- a/examples/bpftrace/kfunc-rcu.bt
+++ b/examples/bpftrace/kfunc-rcu.bt
@@ -1,0 +1,36 @@
+// kfunc-rcu.bt — calling BPF kfuncs from a bpftrace script.
+//
+//   sudo whistler bpftrace examples/bpftrace/kfunc-rcu.bt
+//
+// kfuncs are kernel functions a BPF program *calls* (the modern,
+// extensible alternative to the frozen helper set). In Whistler's
+// bpftrace frontend you call one by its kernel symbol name, and it
+// resolves via BTF at load time — no libbpf.
+//
+// This counts vfs_read() calls inside an RCU read-side critical section,
+// demonstrating the bpf_rcu_read_lock() / bpf_rcu_read_unlock() kfunc
+// pair. Press Ctrl-C to print the count.
+//
+//   Attaching kprobe:vfs_read...
+//   ^C
+//   @reads: 142905
+//
+// NOTE: the kernel gates each kfunc to specific program types. rcu
+// lock/unlock is allowed under kprobe (used here). Acquire/release
+// kfuncs like bpf_task_from_pid()/bpf_task_release() are TRACING-only,
+// so call those from fentry:/kfunc: probes, e.g.:
+//
+//   fentry:vfs_read {
+//     $t = bpf_task_from_pid(pid);   // acquires a refcounted task*
+//     if ($t) {                      // must null-check (may be NULL)
+//       @calls = count();
+//       bpf_task_release($t);        // must release before returning
+//     }
+//   }
+
+kprobe:vfs_read
+{
+  bpf_rcu_read_lock();
+  @reads = count();
+  bpf_rcu_read_unlock();
+}

--- a/examples/kfunc-task.lisp
+++ b/examples/kfunc-task.lisp
@@ -1,0 +1,74 @@
+;;; kfunc-task.lisp — Calling BPF kfuncs with acquire/release semantics
+;;;
+;;; Usage (requires CAP_BPF + CAP_PERFMON, e.g. via
+;;;   sudo setcap cap_bpf,cap_perfmon+ep $(command -v sbcl)):
+;;;
+;;;   sbcl --load examples/kfunc-task.lisp
+;;;
+;;; Expected output:
+;;;   Created map result: fd=... type=2
+;;;   Loaded task_demo: 18 insns, fd=..., section=test_run/task_demo
+;;;   result[0] = 1  (1 = bpf_task_from_pid ran in-kernel)
+;;;
+;;; kfuncs are kernel functions a BPF program *calls* — the modern,
+;;; extensible alternative to the frozen helper set. Whistler resolves
+;;; them by BTF at load time (no libbpf): the call compiles to a
+;;; BPF_PSEUDO_KFUNC_CALL, the ELF carries an R_BPF_64_32 relocation
+;;; against an extern BTF FUNC, and the loader patches in the kfunc's
+;;; vmlinux BTF id.
+;;;
+;;; This program calls bpf_task_from_pid(), which ACQUIRES a refcounted
+;;; task pointer that may be NULL. Whistler enforces both obligations at
+;;; compile time:
+;;;   * :ret-null — the result must be null-checked before use (the (when
+;;;     task ...) below); using it unguarded is a compile error.
+;;;   * :acquire  — the reference must be released on the way out via its
+;;;     paired release kfunc (bpf-task-release); leaking it is a compile
+;;;     error ("acquired reference ... is never released").
+;;; The six phase-1 kfuncs (bpf_rcu_read_lock/unlock, bpf_task_from_pid/
+;;; bpf_task_release, bpf_cgroup_from_id/bpf_cgroup_release) ship
+;;; predeclared; declare your own with (defkfunc ...) — see the bottom.
+;;;
+;;; NOTE ON PROGRAM TYPE: the kernel gates each kfunc to specific program
+;;; types. bpf_task_from_pid is allowed for tracing/syscall/raw_tracepoint
+;;; programs but NOT plain kprobe/xdp — loading it there fails the verifier
+;;; with "calling kernel function ... is not allowed". This example uses a
+;;; test_run/ section (a raw_tracepoint invoked once via BPF_PROG_TEST_RUN)
+;;; so it runs standalone without attaching to anything.
+
+(require :asdf)
+(asdf:load-system "whistler/loader")
+
+(in-package #:whistler)
+
+(defmap result :type :array :key-size 4 :value-size 8 :max-entries 1)
+
+(defprog task-demo (:type :kprobe :section "test_run/task_demo" :license "GPL")
+  (let ((task (bpf-task-from-pid 1)))   ; pid 1 (init) always exists
+    (when task                          ; :ret-null → must null-check
+      (setf (getmap result 0) 1)        ; mark: the kfunc ran in-kernel
+      (bpf-task-release task)))         ; :acquire → must :release
+  0)
+
+(compile-to-elf "/tmp/kfunc-task.bpf.o")
+(format t "Compiled test_run/task_demo to /tmp/kfunc-task.bpf.o~%")
+
+(whistler/loader:with-bpf-object (obj "/tmp/kfunc-task.bpf.o")
+  (let ((prog (whistler/loader:bpf-object-prog obj "task_demo"))
+        (map  (whistler/loader:bpf-object-map  obj "result")))
+    ;; Invoke the program once in the kernel.
+    (whistler/loader:prog-test-run (whistler/loader:prog-info-fd prog))
+    (let ((val (whistler/loader:map-lookup
+                map (whistler/loader:encode-int-key 0 4))))
+      (format t "result[0] = ~d  (1 = bpf_task_from_pid ran in-kernel)~%"
+              (if val (whistler/loader:decode-int-value val) 0)))))
+
+;;; Declaring your own kfunc:
+;;;
+;;;   (defkfunc bpf-cgroup-from-id ((cgid u64)) (ptr cgroup) :acquire :ret-null)
+;;;   (defkfunc bpf-cgroup-release ((cgrp (ptr cgroup))) void :release)
+;;;
+;;; The Lisp name maps to the kernel symbol by turning hyphens into
+;;; underscores (bpf-cgroup-from-id → bpf_cgroup_from_id). Types are
+;;; u8..u64, s32/s64, void, or (ptr STRUCT); flags are :acquire :release
+;;; :ret-null :trusted :sleepable.

--- a/src/bpf.lisp
+++ b/src/bpf.lisp
@@ -86,6 +86,12 @@
 ;; register as the symbol's actual type (e.g. PERCPU_PTR_<T>) instead
 ;; of a plain scalar. Required for `bpf_per_cpu_ptr' to accept R1.
 (defconstant +bpf-pseudo-btf-id+ 3)
+;; src_reg=2 on a BPF_CALL marks the immediate as a kfunc reference.
+;; The imm holds the kfunc's BTF type-id (patched in by the loader from
+;; the target BTF), and off holds a fd_array index for module kfuncs
+;; (0 = vmlinux). The verifier resolves the call against the registered
+;; kfunc set and type-checks its arguments.
+(defconstant +bpf-pseudo-kfunc-call+ 2)
 
 ;; Map types
 (defconstant +bpf-map-type-hash+          1)
@@ -182,6 +188,13 @@
 
 (defun emit-exit ()
   (list (insn (logior +bpf-jmp+ +bpf-exit+) 0 0 0 0)))
+
+(defun emit-kfunc-call (&optional (btf-id 0) (fd-array-idx 0))
+  "Emit a kfunc call. src_reg=+BPF_PSEUDO_KFUNC_CALL+ marks the imm as a
+   kfunc BTF type-id; the loader patches BTF-ID in from the target BTF.
+   FD-ARRAY-IDX (off) selects a module BTF fd (0 = vmlinux)."
+  (list (insn (logior +bpf-jmp+ +bpf-call+) 0 +bpf-pseudo-kfunc-call+
+              fd-array-idx btf-id)))
 
 ;; Byte-swap (endian conversion) instructions
 ;; BPF_ALU | BPF_END | BPF_SRC, imm = bit width

--- a/src/bpftrace/codegen.lisp
+++ b/src/bpftrace/codegen.lisp
@@ -2297,8 +2297,17 @@
   "Per-generate() alist mapping `whistler symbol' → integer id for
    the map-id field on print-map / clear-map records.")
 
+(defun bpftrace-name->kfunc-symbol (name)
+  "If NAME (a bpftrace function name, e.g. \"bpf_task_from_pid\") is a known
+   kfunc's kernel symbol, return the Whistler kfunc symbol to call; else NIL."
+  (let ((entry (find name whistler/compiler:*builtin-kfuncs*
+                     :key (lambda (e) (getf (cdr e) :kernel))
+                     :test #'string=)))
+    (when entry (intern (car entry) '#:whistler))))
+
 (defun lower-call (expr)
-  (let ((name (getf (cdr expr) :name)))
+  (let* ((name (getf (cdr expr) :name))
+         (kfunc-sym (bpftrace-name->kfunc-symbol name)))
     (cond
       ((string= name "count") (unsupported "count() must be on the RHS of @map = …"))
       ((string= name "hist")  (unsupported "hist() must be on the RHS of @map = …"))
@@ -2580,6 +2589,10 @@
       ;; formal parameters with the actual argument expressions.
       ((find-user-function name)
        (inline-user-call name (getf (cdr expr) :args)))
+      ;; kfunc call — the name is a known kfunc's kernel symbol. Lower to a
+      ;; Whistler kfunc call; acquire/release/ret-null checks apply there.
+      (kfunc-sym
+       `(,kfunc-sym ,@(mapcar #'lower-expr (getf (cdr expr) :args))))
       (t (unsupported "function ~A" name)))))
 
 (defun inline-user-call (name args)

--- a/src/btf.lisp
+++ b/src/btf.lisp
@@ -25,6 +25,12 @@
 (defconstant +btf-kind-datasec+   15)
 (defconstant +btf-kind-func-proto+ 13)
 (defconstant +btf-kind-func+      12)
+(defconstant +btf-kind-fwd+        7)
+
+;; BTF_KIND_FUNC linkage (stored in the info vlen field)
+(defconstant +btf-func-static+ 0)
+(defconstant +btf-func-global+ 1)
+(defconstant +btf-func-extern+ 2)
 
 ;; BTF_INT encoding bits
 (defconstant +btf-int-signed+ (ash 1 0))
@@ -73,8 +79,8 @@
   "Encode the BTF type info word: kind in bits 24-28, vlen in bits 0-15."
   (logior (ash kind 24) (logand vlen #xffff)))
 
-(defun btf-add-int (ctx name bits)
-  "Add a BTF_KIND_INT type. Returns the type ID."
+(defun btf-add-int (ctx name bits &optional signedp)
+  "Add a BTF_KIND_INT type. SIGNEDP marks the integer signed. Returns the type ID."
   (let* ((id (btf-alloc-id ctx))
          (name-off (btf-strtab-add (btf-ctx-strtab ctx) name))
          (types (btf-ctx-types ctx)))
@@ -83,11 +89,24 @@
     (btf-emit-u32 types (btf-info-field +btf-kind-int+ 0))
     (btf-emit-u32 types (/ bits 8))  ; size in bytes
     ;; INT data: encoding(8:8), offset(8:8), bits(8:8) packed in 4 bytes
-    ;; encoding = 0 (unsigned), offset = 0, bits = actual bit width
-    (btf-emit-u32 types (logior (ash 0 24)    ; encoding: unsigned
+    (btf-emit-u32 types (logior (ash (if signedp +btf-int-signed+ 0) 24)
                                 (ash 0 16)    ; offset: 0
                                 bits))        ; nr_bits
     (setf (gethash name (btf-ctx-type-cache ctx)) id)
+    id))
+
+(defun btf-add-fwd (ctx name &optional unionp)
+  "Add a BTF_KIND_FWD (forward declaration) for a struct (or union) named
+   NAME. Used as the pointee for kfunc pointer arguments whose full struct
+   layout the object does not carry. Returns the type ID."
+  (let* ((id (btf-alloc-id ctx))
+         (name-off (btf-strtab-add (btf-ctx-strtab ctx) name))
+         (types (btf-ctx-types ctx)))
+    (btf-emit-u32 types name-off)
+    ;; kind_flag (bit 31) selects union(1)/struct(0)
+    (btf-emit-u32 types (logior (btf-info-field +btf-kind-fwd+ 0)
+                                (if unionp (ash 1 31) 0)))
+    (btf-emit-u32 types 0)  ; size_or_type unused for FWD
     id))
 
 (defun btf-resolve-field-type (ctx ftype fname)
@@ -168,17 +187,57 @@
           (btf-emit-u32 types ptype-id))))
     id))
 
-(defun btf-add-func (ctx name proto-type-id)
-  "Add a BTF_KIND_FUNC type. Returns the type ID."
+(defun btf-add-func (ctx name proto-type-id &optional (linkage +btf-func-static+))
+  "Add a BTF_KIND_FUNC type. LINKAGE is BTF_FUNC_STATIC (default),
+   BTF_FUNC_GLOBAL, or BTF_FUNC_EXTERN (kfuncs); it is stored in the info
+   vlen field. Returns the type ID."
   (let* ((id (btf-alloc-id ctx))
          (name-off (btf-strtab-add (btf-ctx-strtab ctx) name))
          (types (btf-ctx-types ctx)))
     ;; FUNC: name_off(4), info(4), type(4) — type points to FUNC_PROTO
     (btf-emit-u32 types name-off)
-    ;; vlen=0 for FUNC; BTF_FUNC_STATIC=0, BTF_FUNC_GLOBAL=1
-    (btf-emit-u32 types (btf-info-field +btf-kind-func+ 0))
+    (btf-emit-u32 types (btf-info-field +btf-kind-func+ linkage))
     (btf-emit-u32 types proto-type-id)
     id))
+
+(defun btf-resolve-kfunc-type (ctx spec)
+  "Resolve a kfunc type-spec to a BTF type ID, creating types on demand.
+   SPEC is void/:void (→ type-id 0), an int name symbol (u8..u64, s32/s64),
+   or (:ptr \"struct_name\") for a pointer to a forward-declared struct."
+  (cond
+    ;; void return / no type
+    ((or (null spec) (eq spec 'void) (eq spec :void)
+         (and (symbolp spec) (string-equal (string spec) "void")))
+     0)
+    ;; pointer to a kernel struct: PTR → FWD(name)
+    ((and (consp spec) (eq (first spec) :ptr))
+     (let* ((sname (string (second spec)))
+            (fwd-key (format nil "fwd:~a" sname))
+            (fwd-id (or (gethash fwd-key (btf-ctx-type-cache ctx))
+                        (setf (gethash fwd-key (btf-ctx-type-cache ctx))
+                              (btf-add-fwd ctx sname))))
+            (ptr-key (format nil "ptr:~a" sname)))
+       (or (gethash ptr-key (btf-ctx-type-cache ctx))
+           (setf (gethash ptr-key (btf-ctx-type-cache ctx))
+                 (btf-add-ptr ctx fwd-id)))))
+    ;; scalar integer type by name
+    (t
+     (let ((tname (string-downcase (string spec))))
+       (or (gethash tname (btf-ctx-type-cache ctx))
+           (error "Unknown kfunc BTF type-spec: ~s" spec))))))
+
+(defun btf-add-kfunc (ctx kernel-name ret-spec arg-specs)
+  "Emit a FUNC_PROTO + extern BTF_KIND_FUNC for a kfunc named KERNEL-NAME
+   (the exact kernel symbol). RET-SPEC and ARG-SPECS are kfunc type-specs.
+   Parameters are named a0, a1, ... (names are not semantically meaningful
+   for kfunc resolution). Returns the FUNC type ID."
+  (let* ((ret-id (btf-resolve-kfunc-type ctx ret-spec))
+         (params (loop for spec in arg-specs
+                       for i from 0
+                       collect (list (format nil "a~d" i)
+                                     (btf-resolve-kfunc-type ctx spec))))
+         (proto-id (btf-add-func-proto ctx ret-id params)))
+    (btf-add-func ctx kernel-name proto-id +btf-func-extern+)))
 
 (defun btf-add-ptr (ctx target-type-id)
   "Add a BTF_KIND_PTR type. Returns the type ID."
@@ -321,11 +380,13 @@
                                  struct-id 1)))  ; linkage=global
         (values var-id struct-size)))))
 
-(defun build-btf-ctx (struct-defs section-names &optional map-specs prog-names)
+(defun build-btf-ctx (struct-defs section-names &optional map-specs prog-names kfunc-sigs)
   "Build a BTF context with base types, struct defs, map defs, and function info.
    SECTION-NAMES is a string or list of strings (one per program).
    MAP-SPECS is a list of (name type key-size value-size max-entries flags).
    PROG-NAMES is a list of defprog name strings (used for BTF FUNC names).
+   KFUNC-SIGS is a list of (kernel-name ret-spec arg-specs) for referenced
+   kfuncs; each becomes an extern BTF_KIND_FUNC.
    Returns (values ctx func-type-ids) where func-type-ids is a list of FUNC type IDs."
   (let ((ctx (make-btf-ctx))
         (names (if (listp section-names) section-names (list section-names))))
@@ -378,6 +439,17 @@
                              names
                              (or prog-names
                                  (make-list (length names) :initial-element nil)))))
+      ;; 6. Add extern FUNC types for referenced kfuncs. Signed base ints
+      ;; are added on demand here (only when kfuncs are present, so objects
+      ;; without kfuncs keep byte-identical BTF).
+      (when kfunc-sigs
+        (unless (gethash "s32" (btf-ctx-type-cache ctx))
+          (btf-add-int ctx "s32" 32 t))
+        (unless (gethash "s64" (btf-ctx-type-cache ctx))
+          (btf-add-int ctx "s64" 64 t))
+        (dolist (sig kfunc-sigs)
+          (destructuring-bind (kernel-name ret-spec arg-specs) sig
+            (btf-add-kfunc ctx kernel-name ret-spec arg-specs))))
       (values ctx func-ids))))
 
 (defun generate-btf (struct-defs section-names)
@@ -558,7 +630,7 @@
           out))))))
 
 (defun generate-btf-and-ext (struct-defs section-names per-section-core-relocs
-                             &optional map-specs &key prog-names)
+                             &optional map-specs &key prog-names kfunc-sigs)
   "Generate both .BTF and .BTF.ext section bytes for one or more programs.
    STRUCT-DEFS: hash table of name -> (total-size . fields).
    SECTION-NAMES: string or list of section name strings.
@@ -572,7 +644,7 @@
                                 per-section-core-relocs
                                 (list per-section-core-relocs))))
     (multiple-value-bind (ctx func-ids)
-        (build-btf-ctx struct-defs names map-specs prog-names)
+        (build-btf-ctx struct-defs names map-specs prog-names kfunc-sigs)
       ;; Add context struct BTF types referenced by CO-RE relocations
       (let ((added (make-hash-table :test 'equal)))
         (dolist (relocs relocs-per-section)

--- a/src/compiler.lisp
+++ b/src/compiler.lisp
@@ -82,6 +82,62 @@
   "Expected argument counts for BPF helpers that users call directly.
    BPF allows max 5 args (R1-R5). Helpers not listed here are not checked.")
 
+;;; Known kfuncs
+;;;
+;;; kfuncs are kernel functions the BPF program *calls*, resolved by BTF
+;;; at load time (unlike helpers, which have stable integer IDs). Each
+;;; entry maps a kebab Lisp name (its SYMBOL-NAME, upcased) to a plist:
+;;;   :kernel   the exact kernel symbol string for BTF resolution
+;;;   :args     ordered list of argument type-specs
+;;;   :ret      return type-spec
+;;;   :flags    list of behaviour keywords
+;;; Type-specs: u8 u16 u32 u64 (unsigned ints), s32 s64 (signed ints),
+;;;   void (no value), or (:ptr "kernel_struct") for a kernel pointer.
+;;; Flag keywords: :acquire (result is a refcounted pointer that must be
+;;;   released), :release (consumes a refcounted pointer), :ret-null
+;;;   (result may be NULL and must be null-checked before use), :trusted
+;;;   (args must be trusted pointers — verifier-enforced), :sleepable.
+;;; Single source of truth — the defkfunc surface macro extends this table,
+;;; and both the BTF emitter and the loader consume it.
+(defparameter *builtin-kfuncs*
+  '(("BPF-RCU-READ-LOCK"
+     :kernel "bpf_rcu_read_lock"   :args ()          :ret void :flags ())
+    ("BPF-RCU-READ-UNLOCK"
+     :kernel "bpf_rcu_read_unlock" :args ()          :ret void :flags ())
+    ("BPF-TASK-FROM-PID"
+     :kernel "bpf_task_from_pid"   :args (s32)        :ret (:ptr "task_struct")
+     :flags (:acquire :ret-null))
+    ("BPF-TASK-RELEASE"
+     :kernel "bpf_task_release"    :args ((:ptr "task_struct")) :ret void
+     :flags (:release))
+    ("BPF-CGROUP-FROM-ID"
+     :kernel "bpf_cgroup_from_id"  :args (u64)        :ret (:ptr "cgroup")
+     :flags (:acquire :ret-null))
+    ("BPF-CGROUP-RELEASE"
+     :kernel "bpf_cgroup_release"  :args ((:ptr "cgroup")) :ret void
+     :flags (:release)))
+  "Known BPF kfuncs: upcased Lisp name → signature plist. See comment above.")
+
+(defun kfunc-spec (name)
+  "Look up a kfunc signature plist by Lisp NAME (symbol or string).
+   Returns NIL if NAME is not a known kfunc."
+  (cdr (assoc (string-upcase (string name)) *builtin-kfuncs* :test #'string=)))
+
+(defun builtin-kfunc-p (sym)
+  "Return the kfunc signature plist if SYM names a known kfunc, or NIL."
+  (and (symbolp sym) (kfunc-spec sym)))
+
+(defun register-kfunc (name kernel args ret flags)
+  "Add or replace a kfunc entry in *builtin-kfuncs*. NAME is the Lisp
+   name (symbol or string); the stored key is its upcased symbol-name.
+   Used by the defkfunc surface macro."
+  (let ((key (string-upcase (string name)))
+        (plist (list :kernel kernel :args args :ret ret :flags flags)))
+    (setf *builtin-kfuncs*
+          (cons (cons key plist)
+                (remove key *builtin-kfuncs* :key #'car :test #'string=)))
+    key))
+
 ;;; Known constants
 
 (defparameter *builtin-constants*
@@ -125,6 +181,7 @@
   (maps '())            ; list of bpf-map structs
   (map-relocs '())      ; list of (insn-index map-index) for relocation
   (core-relocs '())     ; list of (byte-offset struct-name field-name) for CO-RE
+  (kfunc-relocs '())    ; list of (byte-offset kfunc-name) for kfunc call patching
   (section "xdp")       ; ELF section name
   (name nil)            ; defprog name (symbol or string) for FUNC symbol
   (license "GPL"))      ; license string
@@ -324,7 +381,8 @@
          (or (member name *whistler-builtins* :test #'string=)
              (member name *alu-op-names* :test #'string=)
              (member name *jmp-op-names* :test #'string=)
-             (builtin-helper-p sym)))))
+             (builtin-helper-p sym)
+             (builtin-kfunc-p sym)))))
 
 ;;; Macro expansion
 ;;;

--- a/src/elf.lisp
+++ b/src/elf.lisp
@@ -30,7 +30,8 @@
 (defconstant +stb-local+    0)
 (defconstant +stb-global+   1)
 (defconstant +shn-undef+    0)
-(defconstant +r-bpf-64-64+  1)   ; BPF relocation type for map fd
+(defconstant +r-bpf-64-64+  1)   ; BPF relocation type for map fd (ld_imm64)
+(defconstant +r-bpf-64-32+  10)  ; BPF relocation type for call imm (kfunc)
 
 ;;; Binary writing utilities
 
@@ -153,6 +154,20 @@
 
 ;;; Main ELF writer
 
+(defun collect-kfunc-names (prog-sections)
+  "Return the ordered, deduplicated list of kfunc names referenced across
+   PROG-SECTIONS. Each entry's 6th element is its kfunc relocations
+   ((byte-offset name) ...); order follows first appearance."
+  (let ((seen (make-hash-table :test 'equal))
+        (names '()))
+    (dolist (prog-entry prog-sections)
+      (dolist (reloc (sixth prog-entry))
+        (let ((name (second reloc)))
+          (unless (gethash name seen)
+            (setf (gethash name seen) t)
+            (push name names)))))
+    (nreverse names)))
+
 (defun write-bpf-elf (pathname &key prog-sections maps license btf-data btf-ext-data)
   "Write a BPF ELF object file with one or more programs.
    PROG-SECTIONS: list of (section-name prog-bytes relocations core-relocs) per program
@@ -170,6 +185,7 @@
              (syms '())
              (sec-index 0)
              (maps-sec-idx nil)
+             (kfunc-sym-index (make-hash-table :test 'equal))  ; kfunc name → sym idx
              (prog-sec-indices '()))  ; ((section-name . sec-idx) ...)
 
         (labels ((next-sec-idx () (incf sec-index)))
@@ -307,6 +323,23 @@
                                 sec-idx 0 (length prog-bytes))
                     syms)))
 
+          ;; Kfunc extern symbols (global, undefined). One per unique kfunc
+          ;; name referenced by any program. A call relocation targets these;
+          ;; the loader resolves each name to a kernel BTF id at load time.
+          ;; kfunc syms follow map + prog-func syms, so their base index is
+          ;; map-sym-base + n-maps + n-progs. Indices are recorded in the
+          ;; outer kfunc-sym-index table for the relocation loop below.
+          (let ((kfunc-sym-base (+ map-sym-base (length maps)
+                                   (length prog-sections))))
+            (loop for name in (collect-kfunc-names prog-sections)
+                  for i from 0
+                  for name-off = (strtab-add strtab name)
+                  do (setf (gethash name kfunc-sym-index) (+ kfunc-sym-base i))
+                     (push (encode-sym name-off
+                                       (st-info +stb-global+ +stt-notype+) 0
+                                       +shn-undef+ 0 0)
+                           syms)))
+
           ;; Finalize symbol table
           (setf syms (nreverse syms))
           (let* ((num-syms (length syms))
@@ -347,20 +380,35 @@
                           sections)
 
                     ;; -- Relocation sections (one per program with relocations) --
+                    ;; Combines map fd relocations (R_BPF_64_64 on ld_imm64,
+                    ;; sym = a map symbol) and kfunc call relocations
+                    ;; (R_BPF_64_32 on the call imm, sym = an extern kfunc).
+                    ;; A program may have kfunc relocs without any maps.
                     (dolist (prog-entry prog-sections)
                       (let* ((sec-name (first prog-entry))
-                             (relocations (third prog-entry))
+                             (map-relocations (third prog-entry))
+                             (kfunc-relocations (sixth prog-entry))
                              (sec-idx (cdr (assoc sec-name prog-sec-indices
-                                                  :test #'string=))))
-                        (when (and relocations maps)
+                                                  :test #'string=)))
+                             (rel-entries
+                              (append
+                               (when maps
+                                 (loop for (insn-off map-idx) in map-relocations
+                                       collect (encode-rel insn-off
+                                                           (+ map-sym-base map-idx)
+                                                           +r-bpf-64-64+)))
+                               (loop for (insn-off name) in kfunc-relocations
+                                     collect (encode-rel
+                                              insn-off
+                                              (gethash name kfunc-sym-index)
+                                              +r-bpf-64-32+)))))
+                        (when rel-entries
                           (let* ((rel-sec-name (format nil ".rel~a" sec-name))
                                  (rel-name-off (strtab-add shstrtab rel-sec-name))
-                                 (rel-data (make-array (* 16 (length relocations))
+                                 (rel-data (make-array (* 16 (length rel-entries))
                                                        :element-type '(unsigned-byte 8))))
-                            (loop for (insn-off map-idx) in relocations
+                            (loop for entry in rel-entries
                                   for i from 0
-                                  for sym-idx = (+ map-sym-base map-idx)
-                                  for entry = (encode-rel insn-off sym-idx +r-bpf-64-64+)
                                   do (replace rel-data entry :start1 (* i 16)))
                             (next-sec-idx)
                             (push (make-elf-section

--- a/src/emit.lisp
+++ b/src/emit.lisp
@@ -20,6 +20,7 @@
   (next-callee 7)      ; next callee-saved register (7-9, R6 reserved for ctx)
   (stack-offset 0)     ; current stack usage
   (map-relocs '())     ; (byte-offset map-index) pairs
+  (kfunc-relocs '())   ; (kfunc-name) in call-insn order; rebuilt to (byte-offset kfunc-name)
   (ir-prog nil)        ; the IR program
   (fixups '())         ; (bpf-insn-idx target-label) pairs for jump patching
   (key-cache (make-hash-table :test 'equal)) ; canonical key → stack-offset
@@ -457,6 +458,21 @@
               do (let ((map-idx (second (pop old-relocs))))
                    (push (list (* idx 8) map-idx) new-relocs)))
 
+        ;; Rebuild kfunc relocations after peephole. Scan for BPF_CALL
+        ;; insns with src=BPF_PSEUDO_KFUNC_CALL and pair with the recorded
+        ;; names (same order of appearance as emission).
+        (let ((new-kfunc-relocs '())
+              (old-kfunc-relocs (nreverse (emit-ctx-kfunc-relocs ctx))))
+          (loop for insn in bpf-insns
+                for idx from 0
+                when (and (= (whistler/bpf:bpf-insn-code insn)
+                             (logior whistler/bpf:+bpf-jmp+ whistler/bpf:+bpf-call+))
+                          (= (whistler/bpf:bpf-insn-src insn)
+                             whistler/bpf:+bpf-pseudo-kfunc-call+))
+                do (let ((name (pop old-kfunc-relocs)))
+                     (push (list (* idx 8) name) new-kfunc-relocs)))
+          (setf new-kfunc-relocs (nreverse new-kfunc-relocs))
+
         ;; Rebuild CO-RE relocations after peephole.
         ;; Scan for eq-identical BPF insn objects recorded during emission.
         (let ((core-reloc-map (make-hash-table :test 'eq))
@@ -480,7 +496,8 @@
             (setf (whistler/compiler:cu-maps cu) (ir-program-maps prog))
             (setf (whistler/compiler:cu-map-relocs cu) (nreverse new-relocs))
             (setf (whistler/compiler:cu-core-relocs cu) (nreverse final-core-relocs))
-            cu)))))))
+            (setf (whistler/compiler:cu-kfunc-relocs cu) new-kfunc-relocs)
+            cu))))))))
 
 (defun find-ctx-vreg (prog)
   "Find the vreg assigned to %%CTX (the arg0 instruction)."
@@ -526,6 +543,7 @@
      ((eq op :store)     (emit-store-insn ctx args))
      ((eq op :atomic-add)(emit-atomic-add-insn ctx args))
      ((eq op :call)      (emit-call-insn ctx dst args))
+     ((eq op :kfunc-call)(emit-kfunc-call-insn ctx dst args))
      ((eq op :tail-call) (emit-tail-call-insn ctx dst args))
      ((eq op :get-stackid) (emit-get-stackid-insn ctx dst args))
      ((eq op :map-lookup)(emit-map-lookup-insn ctx dst args))
@@ -1438,6 +1456,34 @@
                                           (cons reg (list :stack (cadr loc)))))))))))
       (resolve-parallel-moves ctx moves))
     (ectx-emit ctx (whistler/bpf:emit-call func-id))
+    (when dst (store-to-vreg ctx dst whistler/bpf:+bpf-reg-0+))))
+
+(defun kfunc-arg-name (arg)
+  "Extract kfunc kernel-symbol name from a (:kfunc \"name\") arg."
+  (and (consp arg) (eq (first arg) :kfunc) (second arg)))
+
+(defun emit-kfunc-call-insn (ctx dst args)
+  "Emit a kfunc call. (first args) is (:kfunc NAME); the rest are vreg
+   arguments loaded into R1-R5 exactly like a helper call. The call insn
+   is emitted with imm=0 and src=BPF_PSEUDO_KFUNC_CALL; the NAME is
+   recorded so the loader can patch imm with the kfunc's BTF id."
+  (let ((kfunc-name (kfunc-arg-name (first args)))
+        (call-args (rest args)))
+    (let ((moves (loop for vreg in call-args
+                       for reg from whistler/bpf:+bpf-reg-1+
+                       collect (let ((imm (vreg-imm-or-const ctx vreg)))
+                                 (if imm
+                                     (cons reg (list :imm imm))
+                                     (let ((loc (allocate-vreg ctx vreg)))
+                                       (ecase (car loc)
+                                         (:reg (cons reg (list :reg (cadr loc))))
+                                         (:stack
+                                          (cons reg (list :stack (cadr loc)))))))))))
+      (resolve-parallel-moves ctx moves))
+    ;; Record the kfunc name in call order; byte offset is resolved after
+    ;; peephole by scanning for kfunc call insns (mirrors map relocs).
+    (push kfunc-name (emit-ctx-kfunc-relocs ctx))
+    (ectx-emit ctx (whistler/bpf:emit-kfunc-call))
     (when dst (store-to-vreg ctx dst whistler/bpf:+bpf-reg-0+))))
 
 ;;; ========== Log2 emission ==========

--- a/src/ir.lisp
+++ b/src/ir.lisp
@@ -87,7 +87,7 @@
 (defun ir-insn-side-effect-p (insn)
   "Does this instruction have side effects?"
   (member (ir-insn-op insn)
-          '(:call :tail-call :get-stackid :store :ctx-store :stack-store :atomic-add
+          '(:call :kfunc-call :tail-call :get-stackid :store :ctx-store :stack-store :atomic-add
             :map-update :map-update-ptr :map-delete :map-delete-ptr
             :struct-alloc :br :br-cond :ret
             :ringbuf-reserve :ringbuf-submit :ringbuf-discard
@@ -108,7 +108,7 @@
 
 (defun call-like-op-p (op)
   "Is OP a call-like operation that clobbers caller-saved registers?"
-  (member op '(:call :tail-call :get-stackid :map-lookup
+  (member op '(:call :kfunc-call :tail-call :get-stackid :map-lookup
                :map-update :map-update-ptr
                :map-delete :map-delete-ptr
                :map-lookup-ptr
@@ -151,6 +151,11 @@
            (otherwise
             '(:clobbers-caller-saved :invalidates-packet-ptrs
               :invalidates-map-value-ptrs)))))
+      ;; kfunc call: clobbers caller-saved like any call. The phase-1
+      ;; kfunc set (rcu lock/unlock, task/cgroup acquire/release) does
+      ;; not touch packet or map-value pointers, so no extra invalidation.
+      ((eq op :kfunc-call)
+       '(:clobbers-caller-saved))
       ;; Map-* IR ops: these lower to helper calls that clobber regs
       ;; and invalidate prior map value pointers
       ((member op '(:map-lookup

--- a/src/loader/elf-reader.lisp
+++ b/src/loader/elf-reader.lisp
@@ -28,7 +28,7 @@
   name info shndx value size)
 
 (defstruct elf-rel
-  offset sym-idx)
+  offset sym-idx type)
 
 (defstruct bpf-elf
   sections symtab strtab shstrtab license
@@ -82,11 +82,13 @@
    :size (elf-u64 bytes (+ offset 16))))
 
 (defun parse-rel-entry (bytes offset)
-  "Parse a 16-byte ELF REL entry."
+  "Parse a 16-byte ELF REL entry.
+   r_info packs sym index (high 32) and relocation type (low 32)."
   (let ((r-info (elf-u64 bytes (+ offset 8))))
     (make-elf-rel
      :offset (elf-u64 bytes offset)
-     :sym-idx (ash r-info -32))))
+     :sym-idx (ash r-info -32)
+     :type (logand r-info #xffffffff))))
 
 ;;; ========== Top-level parser ==========
 

--- a/src/loader/loader.lisp
+++ b/src/loader/loader.lisp
@@ -9,6 +9,31 @@
 (defstruct bpf-object
   pathname elf maps progs attachments)
 
+;;; ========== Kfunc relocation patching ==========
+
+(defun patch-kfunc-relocations (insns rel-entries symtab)
+  "Patch kfunc call instructions (R_BPF_64_32 relocations) with the kfunc's
+   kernel BTF id. Each reloc's symbol names a kfunc; its id is resolved in
+   /sys/kernel/btf/vmlinux and written into the call insn's 32-bit imm
+   (bytes offset+4..offset+7). The insn's src_reg (BPF_PSEUDO_KFUNC_CALL)
+   and off (0 = vmlinux) are already baked in by the compiler.
+   Returns a new byte vector with patched instructions."
+  (let ((patched (copy-seq insns))
+        (cache (make-hash-table :test 'equal)))
+    (dolist (rel rel-entries)
+      (let* ((offset (elf-rel-offset rel))
+             (sym-idx (elf-rel-sym-idx rel))
+             (sym (nth sym-idx symtab))
+             (kfunc-name (elf-sym-name sym))
+             (btf-id (or (gethash kfunc-name cache)
+                         (setf (gethash kfunc-name cache)
+                               (resolve-btf-func-id kfunc-name)))))
+        (setf (aref patched (+ offset 4)) (logand btf-id #xff))
+        (setf (aref patched (+ offset 5)) (logand (ash btf-id -8) #xff))
+        (setf (aref patched (+ offset 6)) (logand (ash btf-id -16) #xff))
+        (setf (aref patched (+ offset 7)) (logand (ash btf-id -24) #xff))))
+    patched))
+
 ;;; ========== Top-level API ==========
 
 (defun open-bpf-object (pathname)
@@ -52,9 +77,17 @@
                (prog-name (if func-sym (elf-sym-name func-sym) sec-name))
                (prog-type (section-to-prog-type sec-name)))
 
-          ;; Patch map FD relocations
+          ;; Patch relocations, split by type: map fd (R_BPF_64_64) and
+          ;; kfunc call (R_BPF_64_32) may both appear in one .rel section.
           (when rels
-            (setf insns (patch-map-relocations insns rels symtab map-fds)))
+            (let ((map-rels (remove-if-not
+                             (lambda (r) (= (elf-rel-type r) +r-bpf-64-64+)) rels))
+                  (kfunc-rels (remove-if-not
+                               (lambda (r) (= (elf-rel-type r) +r-bpf-64-32+)) rels)))
+              (when map-rels
+                (setf insns (patch-map-relocations insns map-rels symtab map-fds)))
+              (when kfunc-rels
+                (setf insns (patch-kfunc-relocations insns kfunc-rels symtab)))))
 
           ;; Load program
           (let* ((eat (section-to-expected-attach-type sec-name))

--- a/src/loader/packages.lisp
+++ b/src/loader/packages.lisp
@@ -15,6 +15,7 @@
    #:with-bpf-object #:open-bpf-object #:load-bpf-object #:close-bpf-object
    ;; Accessors
    #:bpf-object-map #:bpf-object-prog #:prog-info-fd #:prog-info-name
+   #:prog-test-run
    ;; Map operations
    #:map-lookup #:map-lookup-int #:map-update #:map-update-int
    #:map-lookup-struct #:map-lookup-struct-int

--- a/src/loader/program.lisp
+++ b/src/loader/program.lisp
@@ -13,6 +13,10 @@
 
 (defconstant +bpf-pseudo-map-fd+ 1)
 
+;; ELF BPF relocation types (r_info low 32 bits)
+(defconstant +r-bpf-64-64+ 1)    ; map fd on ld_imm64
+(defconstant +r-bpf-64-32+ 10)   ; kfunc btf-id on call imm
+
 (defun patch-map-relocations (insns rel-entries symtab map-fds)
   "Patch LD_IMM64 instructions with map FDs based on relocations.
    MAP-FDS is an alist of (symbol-name . fd).

--- a/src/loader/session.lisp
+++ b/src/loader/session.lisp
@@ -83,7 +83,8 @@
                                 :insns (whistler::insn-bytes
                                         (whistler/compiler:cu-insns cu))
                                 :relocs (reverse
-                                         (whistler/compiler:cu-map-relocs cu))))
+                                         (whistler/compiler:cu-map-relocs cu))
+                                :kfunc-relocs (whistler/compiler:cu-kfunc-relocs cu)))
                         compiled-units progs))))))
 
 ;;; ========== Integer key/value encoding ==========
@@ -144,10 +145,21 @@
      (lambda (spec)
        (let* ((insns (copy-seq (getf spec :insns)))
               (relocs (getf spec :relocs))
+              (kfunc-relocs (getf spec :kfunc-relocs))
               (sec-name (getf spec :section))
               (name (getf spec :name))
               (license (getf spec :license))
               (prog-type (section-to-prog-type sec-name)))
+         ;; Patch kfunc call relocations: resolve each kfunc's vmlinux BTF
+         ;; id and write it into the call insn's imm (src_reg/off already
+         ;; baked in by the compiler). Mirrors the ELF loader path.
+         (dolist (rel kfunc-relocs)
+           (let ((offset (first rel))
+                 (btf-id (resolve-btf-func-id (second rel))))
+             (setf (aref insns (+ offset 4)) (logand btf-id #xff))
+             (setf (aref insns (+ offset 5)) (logand (ash btf-id -8) #xff))
+             (setf (aref insns (+ offset 6)) (logand (ash btf-id -16) #xff))
+             (setf (aref insns (+ offset 7)) (logand (ash btf-id -24) #xff))))
          ;; Patch relocations: each reloc is (insn-byte-offset map-index)
          (dolist (rel relocs)
            (let* ((offset (first rel))

--- a/src/lower.lisp
+++ b/src/lower.lisp
@@ -19,7 +19,8 @@
   (env '())           ; ((name type vreg) ...) variable bindings
   (maps '())          ; ((name . bpf-map) ...) map definitions
   (next-id 0)         ; instruction sequence counter
-  (prog-type nil))    ; program type keyword (e.g., :xdp, :cgroup-sock-addr)
+  (prog-type nil)     ; program type keyword (e.g., :xdp, :cgroup-sock-addr)
+  (pending-acquires '())) ; ((kfunc-name . vreg) ...) acquired refs not yet released
 
 (defun ctx-emit (ctx op dst args &optional type)
   "Emit an IR instruction into the current block."
@@ -114,6 +115,10 @@
   "Return the helper ID if SYM names a known BPF helper, or NIL."
   (whistler/compiler:builtin-helper-p sym))
 
+(defun ir-builtin-kfunc-p (sym)
+  "Return the kfunc signature plist if SYM names a known kfunc, or NIL."
+  (whistler/compiler:builtin-kfunc-p sym))
+
 ;;; ========== Main lowering entry point ==========
 
 (defun lower-program (section license maps body &key prog-type)
@@ -149,6 +154,20 @@
         (let ((zero (ctx-fresh-vreg ctx)))
           (ctx-emit ctx :mov zero (list '(:imm 0)) 'u64)
           (ctx-emit ctx :ret nil (list zero)))))
+
+    ;; Leak check: every acquired kfunc reference must be released. This is a
+    ;; lexical must-release-somewhere check — it catches the common leak
+    ;; (acquire, never release). The BPF verifier remains authoritative for
+    ;; per-path completeness (e.g. released on one branch but not another).
+    (when (lower-ctx-pending-acquires ctx)
+      (let ((leaked (remove-duplicates (mapcar #'car (lower-ctx-pending-acquires ctx))
+                                       :test #'equal)))
+        (whistler/compiler:whistler-error
+         :what (format nil "acquired reference from ~{~a~^, ~} is never released"
+                       leaked)
+         :where section
+         :expected "each acquired kfunc pointer released via its paired release kfunc"
+         :hint "call the matching release kfunc (e.g. bpf-task-release, bpf-cgroup-release) before the program returns")))
 
     prog))
 
@@ -430,6 +449,12 @@
              (dst (ctx-fresh-vreg ctx)))
          (ctx-emit ctx :bswap64 dst (list v) 'u64)
          dst))
+
+      ;; (kfunc-name arg1 arg2 ...) — BPF kfunc call in function position.
+      ;; Checked before helpers: the two tables are disjoint, but kfuncs
+      ;; carry acquire/release/ret-null semantics helpers don't.
+      ((ir-builtin-kfunc-p head)
+       (lower-kfunc-call ctx head args))
 
       ;; (helper-name arg1 arg2 ...) — BPF helper call in function position
       ((ir-builtin-helper-p head)
@@ -1271,6 +1296,56 @@
       (check-narrow-pointer-args ctx helper-name args arg-vregs)
       (ctx-emit ctx :call dst (cons `(:helper ,func-id) arg-vregs) 'u64)
       dst)))
+
+;;; ========== Kfunc calls ==========
+
+(defun kfunc-ret-null-form-p (form)
+  "Is FORM a bare call to a :ret-null kfunc? Used to reject direct use of
+   a maybe-null kfunc result where a non-null pointer is required."
+  (and (consp form)
+       (let ((spec (whistler/compiler:builtin-kfunc-p (car form))))
+         (and spec (member :ret-null (getf spec :flags))))))
+
+(defun lower-kfunc-call (ctx kfunc-name args)
+  "Lower a kfunc call. Emits :kfunc-call carrying the kernel symbol name;
+   tracks acquire/release for the leak check and rejects direct use of a
+   maybe-null (:ret-null) result as a kfunc argument."
+  (let ((spec (whistler/compiler:kfunc-spec kfunc-name)))
+    (let* ((kernel (getf spec :kernel))
+           (arg-specs (getf spec :args))
+           (flags (getf spec :flags)))
+      ;; Argument-count check
+      (unless (= (length args) (length arg-specs))
+        (whistler/compiler:whistler-error
+         :what (format nil "~a expects ~d argument~:p, got ~d"
+                       kfunc-name (length arg-specs) (length args))
+         :where (format nil "(~a~{ ~s~})" kfunc-name args)
+         :expected (format nil "(~a~{ ~a~})" kfunc-name arg-specs)))
+      ;; Reject a bare maybe-null kfunc result passed straight into another
+      ;; kfunc (e.g. (bpf-task-release (bpf-task-from-pid pid))). The verifier
+      ;; rejects it too; catching it here gives a clearer message.
+      (dolist (a args)
+        (when (kfunc-ret-null-form-p a)
+          (whistler/compiler:whistler-error
+           :what (format nil "maybe-null result of ~a used directly as an argument to ~a"
+                         (car a) kfunc-name)
+           :where (format nil "(~a ~s ...)" kfunc-name a)
+           :expected "a null-checked pointer (the BPF verifier requires it)"
+           :hint (format nil "bind and guard it: (let ((p ~s)) (when p (~a ...p...)))"
+                         a kfunc-name))))
+      (let ((arg-vregs (mapcar (lambda (a) (lower-expr ctx a)) args)))
+        ;; A :release consumes an acquired reference — clear it from the
+        ;; pending set so it is not reported as leaked.
+        (when (member :release flags)
+          (dolist (v arg-vregs)
+            (setf (lower-ctx-pending-acquires ctx)
+                  (remove v (lower-ctx-pending-acquires ctx) :key #'cdr))))
+        (let ((dst (ctx-fresh-vreg ctx)))
+          (ctx-emit ctx :kfunc-call dst (cons `(:kfunc ,kernel) arg-vregs) 'u64)
+          ;; An :acquire produces a refcounted pointer that must be released.
+          (when (member :acquire flags)
+            (push (cons kfunc-name dst) (lower-ctx-pending-acquires ctx)))
+          dst)))))
 
 ;;; ========== Context load ==========
 

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -19,9 +19,9 @@
    #:emit-ldx-mem #:emit-stx-mem #:emit-st-mem
    #:emit-stx-atomic
    #:emit-jmp-reg #:emit-jmp-imm #:emit-jmp-a
-   #:emit-call #:emit-exit
+   #:emit-call #:emit-exit #:emit-kfunc-call
    #:emit-ld-imm64 #:emit-ld-map-fd #:emit-ld-btf-id
-   #:+bpf-pseudo-btf-id+
+   #:+bpf-pseudo-btf-id+ #:+bpf-pseudo-kfunc-call+
    ;; Constants
    #:+bpf-reg-0+ #:+bpf-reg-1+ #:+bpf-reg-2+ #:+bpf-reg-3+ #:+bpf-reg-4+
    #:+bpf-reg-5+ #:+bpf-reg-6+ #:+bpf-reg-7+ #:+bpf-reg-8+ #:+bpf-reg-9+
@@ -79,7 +79,7 @@
   (:use #:cl #:whistler/bpf)
   (:export #:whistler-error #:*helper-arg-counts*
            #:make-compilation-unit #:cu-insns #:cu-maps
-           #:cu-section #:cu-name #:cu-license #:cu-map-relocs #:cu-core-relocs
+           #:cu-section #:cu-name #:cu-license #:cu-map-relocs #:cu-core-relocs #:cu-kfunc-relocs
            #:whistler-macroexpand #:constant-fold-sexpr #:resolve-map-type
            #:bpf-map #:bpf-map-name #:bpf-map-type #:bpf-map-key-size
            #:bpf-map-value-size #:bpf-map-max-entries #:bpf-map-flags #:bpf-map-index
@@ -87,7 +87,8 @@
            #:sym= #:bpf-type-p #:bpf-type-size #:builtin-helper-p
            #:ctx-resolve-field #:*ctx-btf-resolver*
            #:*prog-type-to-ctx-struct* #:*ctx-struct-fields*
-           #:*builtin-helpers* #:*builtin-constants* #:*whistler-builtins*))
+           #:*builtin-helpers* #:*builtin-constants* #:*whistler-builtins*
+           #:*builtin-kfuncs* #:kfunc-spec #:builtin-kfunc-p #:register-kfunc))
 
 (defpackage #:whistler/ir
   (:use #:cl)
@@ -117,7 +118,7 @@
 (defpackage #:whistler
   (:use #:cl #:whistler/bpf #:whistler/compiler #:whistler/elf #:whistler/btf)
   (:shadow #:case #:defstruct #:incf #:decf)
-  (:export #:compile-file* #:defmap #:defprog #:compile-to-elf #:main
+  (:export #:compile-file* #:defmap #:defprog #:defkfunc #:compile-to-elf #:main
            #:reset-compilation-state
            ;; Surface language macros
            #:when-let #:if-let #:case

--- a/src/whistler.lisp
+++ b/src/whistler.lisp
@@ -511,6 +511,30 @@
     `(push (list ',name :type ,type :section ,sec :license ,license :body ',wrapped-body)
            *programs*)))
 
+(defun %kfunc-type-spec (spec)
+  "Translate a defkfunc surface type into a *builtin-kfuncs* type-spec.
+   (ptr STRUCT) → (:ptr \"struct\"); scalar/void symbols pass through."
+  (cond
+    ((and (consp spec)
+          (symbolp (car spec))
+          (string-equal (symbol-name (car spec)) "PTR"))
+     (list :ptr (substitute #\_ #\- (string-downcase (symbol-name (second spec))))))
+    (t spec)))
+
+(defmacro defkfunc (name params ret &rest flags)
+  "Declare a BPF kfunc so it can be called by NAME like a helper.
+   PARAMS is a list of (var type) pairs; RET is a type; FLAGS are keywords
+   (:acquire :release :ret-null :trusted :sleepable). Types are u8..u64,
+   s32/s64, void, or (ptr STRUCT). The kernel symbol is NAME with hyphens
+   turned to underscores (e.g. bpf-task-from-pid → bpf_task_from_pid).
+   Extends *builtin-kfuncs*; both the BTF emitter and loader pick it up."
+  (let ((kernel (substitute #\_ #\- (string-downcase (symbol-name name))))
+        (arg-specs (mapcar (lambda (p) (%kfunc-type-spec (second p))) params))
+        (ret-spec (%kfunc-type-spec ret)))
+    `(eval-when (:compile-toplevel :load-toplevel :execute)
+       (whistler/compiler:register-kfunc
+        ',name ,kernel ',arg-specs ',ret-spec ',flags))))
+
 (defun wrap-implicit-return (body)
   "If the last form in BODY is not already a (return ...), wrap it."
   (if (null body)
@@ -525,6 +549,28 @@
             body))))
 
 ;;; Compilation
+
+(defun kfunc-sigs-for-units (compiled-units)
+  "Collect the kfuncs referenced across COMPILED-UNITS and return a
+   deduplicated list of (kernel-name ret-spec arg-specs) BTF signatures.
+   The reloc names are exact kernel symbols; signatures come from
+   *builtin-kfuncs* (matched by its :kernel field)."
+  (let ((seen (make-hash-table :test 'equal))
+        (sigs '()))
+    (dolist (cu compiled-units)
+      (dolist (reloc (cu-kfunc-relocs cu))
+        (let ((kernel-name (second reloc)))
+          (unless (gethash kernel-name seen)
+            (setf (gethash kernel-name seen) t)
+            (let ((spec (find kernel-name whistler/compiler:*builtin-kfuncs*
+                              :key (lambda (e) (getf (cdr e) :kernel))
+                              :test #'string=)))
+              (when spec
+                (push (list kernel-name
+                            (getf (cdr spec) :ret)
+                            (getf (cdr spec) :args))
+                      sigs)))))))
+    (nreverse sigs)))
 
 (defun compile-to-elf (output-path &key maps programs)
   "Compile maps and programs to an ELF object file.
@@ -569,15 +615,21 @@
                               (insn-bytes (cu-insns cu))
                               (reverse (cu-map-relocs cu))
                               (cu-core-relocs cu)
-                              (cu-name cu)))
+                              (cu-name cu)
+                              (cu-kfunc-relocs cu)))
                       compiled-units))
              (section-names (mapcar #'first prog-sections))
              (prog-names (mapcar #'fifth prog-sections))
-             (all-core-relocs (mapcar #'fourth prog-sections)))
+             (all-core-relocs (mapcar #'fourth prog-sections))
+             ;; Union of kfuncs referenced across all programs → BTF sigs.
+             ;; Each reloc's kfunc name is the exact kernel symbol; resolve
+             ;; its signature from *builtin-kfuncs* (matched by :kernel).
+             (kfunc-sigs (kfunc-sigs-for-units compiled-units)))
         ;; Generate BTF and BTF.ext for all programs
         (multiple-value-bind (btf btf-ext)
             (generate-btf-and-ext *struct-defs* section-names all-core-relocs
-                                  map-specs :prog-names prog-names)
+                                  map-specs :prog-names prog-names
+                                  :kfunc-sigs kfunc-sigs)
           (write-bpf-elf output-path
                          :prog-sections prog-sections
                          :maps map-specs


### PR DESCRIPTION
Closes #44.

Adds support for calling **BPF kfuncs** — the extensible kernel functions that replaced the frozen helper set — resolved by BTF at load time on Whistler's pure-CL toolchain (no libbpf). Available from **both** the Whistler surface language and the bpftrace frontend.

## How it works

A kfunc call compiles to a `BPF_PSEUDO_KFUNC_CALL`, the ELF carries an `R_BPF_64_32` relocation against an extern BTF `FUNC`, and the loader resolves the kfunc's vmlinux BTF id and patches the call's immediate.

| Layer | Change |
|---|---|
| `bpf.lisp` | `+bpf-pseudo-kfunc-call+` (=2) + `emit-kfunc-call` |
| `ir.lisp` | `:kfunc-call` op (side-effect / call-like / effects) |
| `emit.lisp` | `emit-kfunc-call-insn` + post-peephole kfunc-reloc rebuild |
| `btf.lisp` | extern BTF `FUNC` (linkage 2) + `FWD`/`PTR` types + signed ints |
| `elf.lisp` | extern kfunc symbols + `R_BPF_64_32` call relocations |
| loader | `patch-kfunc-relocations` (`.bpf.o` path) **and** `session-load-progs` (in-memory / bpftrace-runtime path) resolve + patch the call imm |
| `compiler.lisp` | shared `*builtin-kfuncs*` registry + `kfunc-spec`/`register-kfunc` |
| `lower.lisp` | `lower-kfunc-call` + acquire/release leak check + ret-null direct-use check |
| `whistler.lisp` | `defkfunc` surface macro; BTF signature threading |
| `bpftrace/codegen.lisp` | `lower-call` recognizes a kfunc by its kernel symbol name |

## Surface

Call a kfunc by name like a helper. Six ship predeclared (`bpf-rcu-read-lock`/`unlock`, `bpf-task-from-pid`/`bpf-task-release`, `bpf-cgroup-from-id`/`bpf-cgroup-release`); declare more with `defkfunc`:

```lisp
(defkfunc bpf-task-from-pid ((pid s32)) (ptr task_struct) :acquire :ret-null)
(defkfunc bpf-task-release  ((task (ptr task_struct))) void :release)

(defprog task-demo (:type :kprobe :section "test_run/task_demo")
  (let ((task (bpf-task-from-pid 1)))   ; :ret-null -> must null-check
    (when task
      (bpf-task-release task)))         ; :acquire -> must release
  0)
```

Acquire/release and maybe-null pointers are checked at compile time (a leaked acquired reference or an unguarded `:ret-null` result is a compile error). The verifier remains authoritative for per-path completeness and the per-program-type kfunc allowlist.

## Verification

Tested end-to-end against a live kernel from both frontends:
- Whistler `test_run` program acquires/releases a task and runs via `BPF_PROG_TEST_RUN` (result confirms the kfunc executed in-kernel).
- bpftrace `kprobe:vfs_read { bpf_rcu_read_lock(); @reads = count(); bpf_rcu_read_unlock(); }` attaches and prints counts.
- Per-program-type gating confirmed (e.g. `bpf_task_from_pid` rejected under kprobe/xdp — kernel allowlist, not a bug).
- No regression on existing examples.

## Examples & docs

- `examples/kfunc-task.lisp`, `examples/bpftrace/kfunc-rcu.bt`
- CLAUDE.md, README.md, CHANGELOG.md, doc/MANUAL.md, mdBook (`book/src/language/kfuncs.md` + SUMMARY + bpftrace/surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)