### PR TITLE
Fix ring consumer use-after-close; validate the ELF header before reading it

### DIFF
--- a/src/loader/elf-reader.lisp
+++ b/src/loader/elf-reader.lisp
@@ -8,6 +8,9 @@
 
 ;;; ELF constants and byte readers come from whistler/binary.
 
+(defconstant +elf64-ehdr-size+ 64
+  "Size of an ELF64 file header, and so the smallest file that can carry one.")
+
 ;;; ========== Data structures ==========
 
 (defstruct elf-section
@@ -66,17 +69,19 @@
 
 (defun read-bpf-elf (pathname)
   "Parse a BPF ELF object file. Returns a bpf-elf structure."
-  (let* ((bytes (read-elf-bytes pathname))
-         ;; Validate ELF header
-         (magic (u32 bytes 0))
-         (class (aref bytes 4))
-         (data (aref bytes 5))
-         (machine (u16 bytes 18)))
-    (unless (= magic +elf-magic+)
+  (let ((bytes (read-elf-bytes pathname)))
+    ;; Validate ELF header. A field only means anything once the file has been
+    ;; shown to be long enough to hold it, so measure before reading.
+    (unless (and (>= (length bytes) 4) (= (u32 bytes 0) +elf-magic+))
       (error "Not an ELF file: ~a" pathname))
-    (unless (and (= class 2) (= data 1) (= machine +em-bpf+))
-      (error "Not a 64-bit LE BPF ELF: class=~d data=~d machine=~d"
-             class data machine))
+    (unless (>= (length bytes) +elf64-ehdr-size+)
+      (error "Truncated ELF header: ~a is ~d bytes" pathname (length bytes)))
+    (let ((class (aref bytes 4))
+          (data (aref bytes 5))
+          (machine (u16 bytes 18)))
+      (unless (and (= class 2) (= data 1) (= machine +em-bpf+))
+        (error "Not a 64-bit LE BPF ELF: class=~d data=~d machine=~d"
+               class data machine)))
 
     (multiple-value-bind (e-shoff e-shentsize e-shnum e-shstrndx)
         (elf64-shdr-table bytes)

--- a/src/loader/ringbuf.lisp
+++ b/src/loader/ringbuf.lisp
@@ -19,7 +19,7 @@
 
 (defstruct ring-consumer
   map-fd ring-size mmap-ptr consumer-ptr producer-ptr data-ptr
-  epoll-fd callback)
+  epoll-fd callback closed)
 
 (defun page-size ()
   4096)
@@ -85,8 +85,18 @@
           (progn ,@body)
        (close-ring-consumer ,var))))
 
+(defun check-ring-consumer-open (consumer context)
+  "Refuse CONTEXT on a closed consumer. The mmapped pages are gone and the
+   epoll fd may have been reissued, and neither a raw SAP read nor a syscall
+   on a recycled descriptor reports the mistake on its own."
+  (when (ring-consumer-closed consumer)
+    (error 'bpf-error
+           :context (format nil "~a on a closed ring consumer" context)
+           :errno 9)))  ; EBADF
+
 (defun ring-poll (consumer &key (timeout-ms 100))
   "Wait for ring buffer events, then consume them. Returns event count."
+  (check-ring-consumer-open consumer "ring-poll")
   (let ((event-buf (make-array 12 :element-type '(unsigned-byte 8) :initial-element 0)))
     (sb-sys:with-pinned-objects (event-buf)
       (let ((ret (syscall +sys-epoll-wait+
@@ -100,6 +110,7 @@
 
 (defun ring-consume (consumer)
   "Process all available events in the ring buffer. Returns event count."
+  (check-ring-consumer-open consumer "ring-consume")
   (let* ((ring-size (ring-consumer-ring-size consumer))
          (mask (1- ring-size))
          (data-ptr (ring-consumer-data-ptr consumer))
@@ -134,12 +145,27 @@
     count))
 
 (defun close-ring-consumer (consumer)
-  "Close a ring buffer consumer, unmapping memory and closing epoll."
-  (let ((pgsz (page-size))
-        (ring-size (ring-consumer-ring-size consumer)))
-    ;; Unmap consumer page (rw)
-    (sb-posix:munmap (ring-consumer-mmap-ptr consumer) pgsz)
-    ;; Unmap producer + data pages (ro)
-    (sb-posix:munmap (ring-consumer-producer-ptr consumer)
-                     (+ pgsz (* 2 ring-size))))
-  (sb-posix:close (ring-consumer-epoll-fd consumer)))
+  "Close a ring buffer consumer, unmapping memory and closing epoll.
+   Idempotent: a second close is a no-op, so it can never unmap a region
+   or close a descriptor the process has since handed to something else."
+  (unless (ring-consumer-closed consumer)
+    (let ((pgsz (page-size))
+          (ring-size (ring-consumer-ring-size consumer))
+          (rw-ptr (ring-consumer-mmap-ptr consumer))
+          (ro-ptr (ring-consumer-producer-ptr consumer))
+          (epoll-fd (ring-consumer-epoll-fd consumer)))
+      ;; Drop every handle first. Whatever the syscalls below do, this
+      ;; consumer is finished with these resources and must not name them
+      ;; again — nor let ring-poll or ring-consume read through them.
+      (setf (ring-consumer-closed consumer) t
+            (ring-consumer-mmap-ptr consumer) nil
+            (ring-consumer-consumer-ptr consumer) nil
+            (ring-consumer-producer-ptr consumer) nil
+            (ring-consumer-data-ptr consumer) nil
+            (ring-consumer-epoll-fd consumer) nil)
+      ;; Unmap consumer page (rw)
+      (sb-posix:munmap rw-ptr pgsz)
+      ;; Unmap producer + data pages (ro)
+      (sb-posix:munmap ro-ptr (+ pgsz (* 2 ring-size)))
+      (sb-posix:close epoll-fd)))
+  nil)

--- a/tests/test-loader.lisp
+++ b/tests/test-loader.lisp
@@ -1,7 +1,7 @@
 (in-package #:whistler/tests)
 
 (def-suite loader-suite
-  :description "whistler/loader: ring buffer consumer lifetime"
+  :description "whistler/loader: ring buffer consumer lifetime, ELF header validation"
   :in whistler-suite)
 
 (in-suite loader-suite)
@@ -131,3 +131,100 @@
              "ring-poll waited on a descriptor the consumer no longer owns")
       (sb-posix:munmap rw +ring-test-page-size+)
       (sb-posix:munmap ro (ring-test-ro-size)))))
+
+;;; ========== ELF header validation ==========
+;;;
+;;; A caller who hands the loader something that is not a BPF object should be
+;;; told exactly that. The header fields only mean anything once the file has
+;;; been shown to be long enough to carry them, so each read has to sit behind
+;;; the check that justifies it.
+
+(defun octets (sequence)
+  (coerce sequence '(vector (unsigned-byte 8))))
+
+(defun ascii-octets (string)
+  (map '(vector (unsigned-byte 8)) #'char-code string))
+
+(defun elf-ident-octets ()
+  "The four identification bytes at the head of every ELF file."
+  (octets (list #x7f (char-code #\E) (char-code #\L) (char-code #\F))))
+
+(defun elf64-header-octets (&key (class 2) (data 1)
+                                 (machine whistler/binary:+em-bpf+))
+  "Build a 64-byte ELF64 header carrying the fields the loader inspects.
+   Every other byte is left zero."
+  (let ((header (make-array 64 :element-type '(unsigned-byte 8)
+                               :initial-element 0)))
+    (replace header (elf-ident-octets))
+    (setf (aref header 4) class
+          (aref header 5) data
+          (aref header 18) (ldb (byte 8 0) machine)
+          (aref header 19) (ldb (byte 8 8) machine))
+    header))
+
+(defun elf-parse-condition (bytes)
+  "Write BYTES to a temp file and parse it as a BPF ELF. Returns the condition
+   the parse signalled, or NIL when it parsed without complaint."
+  (uiop:with-temporary-file (:stream out :pathname path
+                             :element-type '(unsigned-byte 8))
+    (write-sequence bytes out)
+    (finish-output out)
+    (handler-case (progn (whistler/loader::read-bpf-elf path) nil)
+      (error (e) e))))
+
+(defun reports-p (condition text)
+  (and condition (search text (princ-to-string condition)) t))
+
+(test a-short-non-elf-file-is-reported-as-not-an-elf
+  (let ((condition (elf-parse-condition (ascii-octets "not an elf!!!"))))
+    (is (not (typep condition 'sb-int:invalid-array-index-error))
+        "the parser indexed past the end of the file instead of checking it: ~a"
+        condition)
+    (is (reports-p condition "Not an ELF file")
+        "wanted a report that the file is not an ELF, got: ~a" condition)))
+
+(test a-file-too-short-for-the-magic-is-reported-as-not-an-elf
+  (dolist (length '(0 1 2 3))
+    (let ((condition (elf-parse-condition (subseq (elf-ident-octets) 0 length))))
+      (is (not (typep condition 'sb-int:invalid-array-index-error))
+          "a ~D-byte file was indexed rather than measured: ~a" length condition)
+      (is (reports-p condition "Not an ELF file")
+          "wanted a report that a ~D-byte file is not an ELF, got: ~a"
+          length condition))))
+
+(test a-truncated-elf-header-is-reported-as-truncated
+  (let ((condition (elf-parse-condition (subseq (elf64-header-octets) 0 32))))
+    (is (not (typep condition 'sb-int:invalid-array-index-error))
+        "the section-header geometry was read out of a half-length header: ~a"
+        condition)
+    (is (reports-p condition "Truncated ELF header")
+        "wanted a report that the header is short, got: ~a" condition)))
+
+(test a-non-bpf-elf-keeps-its-own-report
+  ;; EM_X86_64 — a genuine ELF, just not one this loader can use.
+  (let ((condition (elf-parse-condition (elf64-header-octets :machine 62))))
+    (is (not (typep condition 'sb-int:invalid-array-index-error))
+        "a well-formed header failed on an index rather than on its machine: ~a"
+        condition)
+    (is (reports-p condition "Not a 64-bit LE BPF ELF")
+        "wanted the machine-mismatch report, got: ~a" condition)))
+
+(test a-compiled-bpf-object-still-parses
+  (uiop:with-temporary-file (:stream source :pathname source-path :type "lisp")
+    (write-string "(in-package #:whistler)
+                   (defprog elf-header-probe
+                       (:type :xdp :section \"xdp\" :license \"GPL\")
+                     (return 2))"
+                  source)
+    (finish-output source)
+    (let ((object-path (make-pathname :type "bpf.o" :defaults source-path)))
+      (unwind-protect
+           (progn
+             (whistler::compile-file* source-path object-path)
+             (let ((elf (whistler/loader::read-bpf-elf object-path)))
+               (is (string= "GPL" (whistler/loader::bpf-elf-license elf))
+                   "license section did not survive the round trip")
+               (is (= 1 (length (whistler/loader::bpf-elf-prog-sections elf)))
+                   "wanted one program section, got ~D"
+                   (length (whistler/loader::bpf-elf-prog-sections elf)))))
+        (when (probe-file object-path) (delete-file object-path))))))

--- a/tests/test-loader.lisp
+++ b/tests/test-loader.lisp
@@ -1,0 +1,133 @@
+(in-package #:whistler/tests)
+
+(def-suite loader-suite
+  :description "whistler/loader: ring buffer consumer lifetime"
+  :in whistler-suite)
+
+(in-suite loader-suite)
+
+;;; A ring consumer owns two mmapped regions and an epoll fd, and close is
+;;; the interesting path. It can be exercised without CAP_BPF and without a
+;;; real ringbuf map: build the consumer over anonymous pages and a bare
+;;; epoll fd, both of which an unprivileged process can create. Close then
+;;; unmaps memory this process really owns and closes an fd it really holds,
+;;; so nothing here can fault the image.
+
+(defconstant +ring-test-page-size+ 4096)
+(defconstant +ring-test-ring-size+ 4096)
+
+;;; MAP_FIXED_NOREPLACE — take an address back only if it is still free,
+;;; rather than evicting whatever the runtime may have put there.
+(defconstant +map-fixed-noreplace+ #x100000)
+
+(defun ring-test-ro-size ()
+  (+ +ring-test-page-size+ (* 2 +ring-test-ring-size+)))
+
+(defun map-anon-pages (size &optional addr)
+  "Map SIZE bytes of private anonymous memory. With ADDR, map at that exact
+   address, so a region a close has unmapped becomes valid memory again."
+  (sb-posix:mmap addr size
+                 (logior sb-posix:prot-read sb-posix:prot-write)
+                 (logior sb-posix:map-private sb-posix:map-anon
+                         (if addr +map-fixed-noreplace+ 0))
+                 -1 0))
+
+(defun make-test-ring-consumer ()
+  "Build a ring-consumer over anonymous pages and a real epoll fd."
+  (let* ((rw (map-anon-pages +ring-test-page-size+))
+         (ro (map-anon-pages (ring-test-ro-size)))
+         (epoll-fd (whistler/loader::syscall
+                    whistler/loader::+sys-epoll-create1+
+                    whistler/loader::+epoll-cloexec+)))
+    (whistler/loader::make-ring-consumer
+     :map-fd -1
+     :ring-size +ring-test-ring-size+
+     :mmap-ptr rw
+     :consumer-ptr rw
+     :producer-ptr ro
+     :data-ptr (sb-sys:sap+ ro +ring-test-page-size+)
+     :epoll-fd epoll-fd
+     :callback (lambda (sap len) (declare (ignore sap len))))))
+
+(defun stage-one-event (consumer-ptr producer-ptr data-ptr)
+  "Lay one committed 4-byte event into the pages a ring consumer reads, so
+   that a consumer which does read them reports an event rather than zero."
+  (setf (sb-sys:sap-ref-64 consumer-ptr 0) 0)
+  (setf (sb-sys:sap-ref-32 data-ptr 0) 4)
+  (setf (sb-sys:sap-ref-64 producer-ptr 0)
+        (logand (+ 4 whistler/loader::+bpf-ringbuf-hdr-size+ 7) (lognot 7))))
+
+(defun fd-open-p (fd)
+  (handler-case (progn (sb-posix:fcntl fd sb-posix:f-getfd) t)
+    (sb-posix:syscall-error () nil)))
+
+(defun signals-bpf-error-p (thunk)
+  (handler-case (progn (funcall thunk) nil)
+    (whistler/loader:bpf-error () t)))
+
+;;; ========== Close is a one-shot operation ==========
+
+(test closing-a-ring-consumer-twice-spares-the-reissued-fd
+  (let* ((consumer (make-test-ring-consumer))
+         (rw (whistler/loader::ring-consumer-mmap-ptr consumer))
+         (ro (whistler/loader::ring-consumer-producer-ptr consumer))
+         (epoll-fd (whistler/loader::ring-consumer-epoll-fd consumer)))
+    (whistler/loader:close-ring-consumer consumer)
+    ;; Take the addresses back so a second close unmaps memory we own.
+    (map-anon-pages +ring-test-page-size+ rw)
+    (map-anon-pages (ring-test-ro-size) ro)
+    ;; The kernel hands out the lowest free descriptor, so this lands on the
+    ;; number the consumer just gave up.
+    (let ((reused-fd (whistler/loader::syscall
+                      whistler/loader::+sys-epoll-create1+
+                      whistler/loader::+epoll-cloexec+)))
+      (unwind-protect
+           (progn
+             (is (= reused-fd epoll-fd)
+                 "the test needs the descriptor reissued: got ~D, wanted ~D"
+                 reused-fd epoll-fd)
+             (whistler/loader:close-ring-consumer consumer)
+             (is (fd-open-p reused-fd)
+                 "the second close closed descriptor ~D, which now belongs to something else"
+                 reused-fd))
+        (when (fd-open-p reused-fd)
+          (sb-posix:close reused-fd))
+        (sb-posix:munmap rw +ring-test-page-size+)
+        (sb-posix:munmap ro (ring-test-ro-size))))))
+
+;;; ========== Reading after close ==========
+
+(test ring-consume-refuses-a-closed-consumer
+  (let* ((consumer (make-test-ring-consumer))
+         (rw (whistler/loader::ring-consumer-mmap-ptr consumer))
+         (ro (whistler/loader::ring-consumer-producer-ptr consumer))
+         (data (whistler/loader::ring-consumer-data-ptr consumer)))
+    (whistler/loader:close-ring-consumer consumer)
+    ;; Make the surrendered addresses valid and event-shaped again. This is
+    ;; what an unlucky reallocation looks like from the outside, and it is
+    ;; what the consumer's stale pointers would read.
+    (map-anon-pages +ring-test-page-size+ rw)
+    (map-anon-pages (ring-test-ro-size) ro)
+    (stage-one-event rw ro data)
+    (unwind-protect
+         (is (signals-bpf-error-p
+              (lambda () (whistler/loader:ring-consume consumer)))
+             "ring-consume read the recycled pages instead of signalling")
+      (sb-posix:munmap rw +ring-test-page-size+)
+      (sb-posix:munmap ro (ring-test-ro-size)))))
+
+(test ring-poll-refuses-a-closed-consumer
+  (let* ((consumer (make-test-ring-consumer))
+         (rw (whistler/loader::ring-consumer-mmap-ptr consumer))
+         (ro (whistler/loader::ring-consumer-producer-ptr consumer))
+         (data (whistler/loader::ring-consumer-data-ptr consumer)))
+    (whistler/loader:close-ring-consumer consumer)
+    (map-anon-pages +ring-test-page-size+ rw)
+    (map-anon-pages (ring-test-ro-size) ro)
+    (stage-one-event rw ro data)
+    (unwind-protect
+         (is (signals-bpf-error-p
+              (lambda () (whistler/loader:ring-poll consumer :timeout-ms 0)))
+             "ring-poll waited on a descriptor the consumer no longer owns")
+      (sb-posix:munmap rw +ring-test-page-size+)
+      (sb-posix:munmap ro (ring-test-ro-size)))))

--- a/whistler.asd
+++ b/whistler.asd
@@ -118,4 +118,5 @@
                (:file "test-differential")
                (:file "test-torture")
                (:file "test-bpftrace")
-               (:file "test-symbolize")))
+               (:file "test-symbolize")
+               (:file "test-loader")))


### PR DESCRIPTION
Two loader fixes, one commit each. Closes #46 and #47.

I made close-ring-consumer one-shot because both of its failure modes are reachable from ordinary
use and neither reports itself. A second close names resources the process has already surrendered,
and a read after close goes through stale SAPs, which carry no bounds check. Close a consumer twice
now and the second call does nothing. Call ring-poll or ring-consume on a closed one and you get a
bpf-error rather than whatever happens to be mapped at that address.

with-decoding-ring-consumer needs no change: closing twice through its cleanup path is now harmless.

I reordered the ELF header validation because handing the loader a file that is not an ELF object
should get you that answer, not an array index error from inside the reader. I put the length check
ahead of the magic check because an empty file died on the magic read itself, so checking the magic
first would have fixed only half of it. I kept both existing error messages word for word, since a
caller may be matching on them. The one new message covers the case the old ones could not describe
honestly, a file that is an ELF but too short to read.

I wrote the tests to need neither CAP_BPF nor a real ringbuf map, so you can run them on an ordinary
checkout. The use-after-close tests reproduce the silent corruption rather than a fault, so they
cannot take the image down on a machine that runs them. Each of them fails against master without
these two commits.

Verification, and what it does not cover:

The suite is 894 checks, all passing, on Linux 6.12.95 x86_64 with CAP_BPF available, SBCL 2.6.4.
Every one of the 162 programs the torture suite generates was loaded into the kernel and accepted by
the verifier. The commit messages quote 716 and 732 because those runs had no CAP_BPF: without it
the torture tests compile and stop, and each program kernel-verified adds a further check, which is
the whole of the difference between 732 and 894.

That covers one kernel version and one architecture, and says nothing about another version or about
aarch64. The verifier accepting a program establishes that it is safe to load, not that it computes
the right answer. 162 is what this suite generates, not the space of programs the compiler can emit.

© Brian O'Reilly <fade@deepsky.com>, 2026
